### PR TITLE
Investigate and fix reordering bug in EditWordForm

### DIFF
--- a/client/component/compound/edit-word-form/edit-template-word-form-edit-part.tsx
+++ b/client/component/compound/edit-word-form/edit-template-word-form-edit-part.tsx
@@ -34,7 +34,8 @@ export const EditTemplateWordFormEditPart = create(
     const sectionOperations = useMemo(() => ({
       append: sectionFieldArraySpec.append,
       update: sectionFieldArraySpec.update,
-      remove: sectionFieldArraySpec.remove
+      remove: sectionFieldArraySpec.remove,
+      move: sectionFieldArraySpec.move
     }), [sectionFieldArraySpec]);
 
     const sections = sectionFieldArraySpec.fields;
@@ -59,7 +60,7 @@ export const EditTemplateWordFormEditPart = create(
           <EditTemplateWordFormBasicSection dictionary={dictionary} form={form}/>
           {(dictionary.settings.enableAdvancedWord) ? (
             <div styleName="section-list">
-              <SwapAnimationContext values={sections} setValues={setSections}>
+              <SwapAnimationContext values={sections} setValues={setSections} move={sectionFieldArraySpec.move}>
                 {sections.map((section, sectionIndex) => (
                   <EditTemplateWordFormSectionSection
                     key={section.id}
@@ -81,7 +82,7 @@ export const EditTemplateWordFormEditPart = create(
             </div>
           ) : (
             <div styleName="section-list">
-              <SwapAnimationContext values={sections} setValues={setSections}>
+              <SwapAnimationContext values={sections} setValues={setSections} move={sectionFieldArraySpec.move}>
                 <EditTemplateWordFormSectionSection
                   dictionary={dictionary}
                   form={form}

--- a/client/component/compound/edit-word-form/edit-template-word-form-relation-section.tsx
+++ b/client/component/compound/edit-word-form/edit-template-word-form-relation-section.tsx
@@ -53,7 +53,7 @@ export const EditTemplateWordFormRelationSection = create(
         <h4 styleName="heading">{trans("heading.relations")}</h4>
         <div styleName="list">
           {(relations.length > 0) ? (
-            <EditWordFormDndContext values={relations} setValues={setRelations}>
+            <EditWordFormDndContext values={relations} setValues={setRelations} move={relationOperations.move}>
               {relations.map((relation, index) => (
                 <EditTemplateWordFormRelationItem
                   styleName="item"

--- a/client/component/compound/edit-word-form/edit-word-form-dnd.tsx
+++ b/client/component/compound/edit-word-form/edit-word-form-dnd.tsx
@@ -13,10 +13,12 @@ export const EditWordFormDndContext = create(
   function <T extends {id: string}>({
     values,
     setValues,
+    move,
     children
   }: {
     values: Array<T>,
     setValues: (update: (values: Array<T>) => Array<T>) => void,
+    move?: (fromIndex: number, toIndex: number) => void,
     children: ReactNode
   }): ReactElement {
 
@@ -29,9 +31,13 @@ export const EditWordFormDndContext = create(
       if (over && active.id !== over.id) {
         const activeIndex = values.findIndex((value) => value.id === active.id);
         const overIndex = values.findIndex((value) => value.id === over.id);
-        setValues((values) => moveArrayItem(values, activeIndex, overIndex));
+        if (move) {
+          move(activeIndex, overIndex);
+        } else {
+          setValues((values) => moveArrayItem(values, activeIndex, overIndex));
+        }
       }
-    }, [values, setValues]);
+    }, [values, setValues, move]);
 
     return (
       <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictToVerticalAxis]} onDragEnd={handleDragEnd}>

--- a/client/component/compound/edit-word-form/edit-word-form-edit-part.tsx
+++ b/client/component/compound/edit-word-form/edit-word-form-edit-part.tsx
@@ -34,7 +34,8 @@ export const EditWordFormEditPart = create(
     const sectionOperations = useMemo(() => ({
       append: sectionFieldArraySpec.append,
       update: sectionFieldArraySpec.update,
-      remove: sectionFieldArraySpec.remove
+      remove: sectionFieldArraySpec.remove,
+      move: sectionFieldArraySpec.move
     }), [sectionFieldArraySpec]);
 
     const sections = sectionFieldArraySpec.fields;
@@ -59,7 +60,7 @@ export const EditWordFormEditPart = create(
           <EditWordFormBasicSection dictionary={dictionary} form={form}/>
           {(dictionary.settings.enableAdvancedWord) ? (
             <div styleName="section-list">
-              <SwapAnimationContext values={sections} setValues={setSections}>
+              <SwapAnimationContext values={sections} setValues={setSections} move={sectionFieldArraySpec.move}>
                 {sections.map((section, sectionIndex) => (
                   <EditWordFormSectionSection
                     key={section.id}
@@ -81,7 +82,7 @@ export const EditWordFormEditPart = create(
             </div>
           ) : (
             <div styleName="section-list">
-              <SwapAnimationContext values={sections} setValues={setSections}>
+              <SwapAnimationContext values={sections} setValues={setSections} move={sectionFieldArraySpec.move}>
                 <EditWordFormSectionSection
                   dictionary={dictionary}
                   form={form}

--- a/client/component/compound/edit-word-form/edit-word-form-equivalent-section.tsx
+++ b/client/component/compound/edit-word-form/edit-word-form-equivalent-section.tsx
@@ -54,8 +54,8 @@ export const EditWordFormEquivalentSection = create(
         <h4 styleName="heading">{trans("heading.equivalents")}</h4>
         <div styleName="list">
           {(equivalents.length > 0) ? (
-            <SwapAnimationContext values={equivalents} setValues={setEquivalents}>
-              <EditWordFormDndContext values={equivalents} setValues={setEquivalents}>
+            <SwapAnimationContext values={equivalents} setValues={setEquivalents} move={equivalentFieldArraySpec.move}>
+              <EditWordFormDndContext values={equivalents} setValues={setEquivalents} move={equivalentFieldArraySpec.move}>
                 {equivalents.map((equivalent, equivalentIndex) => (
                   <EditWordFormEquivalentItem
                     styleName="item"

--- a/client/component/compound/edit-word-form/edit-word-form-information-section.tsx
+++ b/client/component/compound/edit-word-form/edit-word-form-information-section.tsx
@@ -61,8 +61,8 @@ export const EditWordFormInformationSection = create(
         <h4 styleName="heading">{trans("heading.informations")}</h4>
         <div styleName="list">
           {(informations.length > 0) ? (
-            <SwapAnimationContext values={informations} setValues={setInformations}>
-              <EditWordFormDndContext values={informations} setValues={setInformations}>
+            <SwapAnimationContext values={informations} setValues={setInformations} move={informationFieldArraySpec.move}>
+              <EditWordFormDndContext values={informations} setValues={setInformations} move={informationFieldArraySpec.move}>
                 {informations.map((information, index) => (
                   <EditWordFormInformationItem
                     styleName="item"

--- a/client/component/compound/edit-word-form/edit-word-form-phrase-section.tsx
+++ b/client/component/compound/edit-word-form/edit-word-form-phrase-section.tsx
@@ -60,8 +60,8 @@ export const EditWordFormPhraseSection = create(
         <h4 styleName="heading">{trans("heading.phrases")}</h4>
         <div styleName="list">
           {(phrases.length > 0) ? (
-            <SwapAnimationContext values={phrases} setValues={setPhrases}>
-              <EditWordFormDndContext values={phrases} setValues={setPhrases}>
+            <SwapAnimationContext values={phrases} setValues={setPhrases} move={phraseFieldArraySpec.move}>
+              <EditWordFormDndContext values={phrases} setValues={setPhrases} move={phraseFieldArraySpec.move}>
                 {phrases.map((phrase, index) => (
                   <EditWordFormPhraseItem
                     styleName="item"

--- a/client/component/compound/edit-word-form/edit-word-form-relation-section.tsx
+++ b/client/component/compound/edit-word-form/edit-word-form-relation-section.tsx
@@ -59,8 +59,8 @@ export const EditWordFormRelationSection = create(
         <h4 styleName="heading">{trans("heading.relations")}</h4>
         <div styleName="list">
           {(relations.length > 0) ? (
-            <SwapAnimationContext values={relations} setValues={setRelations}>
-              <EditWordFormDndContext values={relations} setValues={setRelations}>
+            <SwapAnimationContext values={relations} setValues={setRelations} move={relationFieldArraySpec.move}>
+              <EditWordFormDndContext values={relations} setValues={setRelations} move={relationFieldArraySpec.move}>
                 {relations.map((relation, index) => (
                   <EditWordFormRelationItem
                     styleName="item"

--- a/client/component/compound/edit-word-form/edit-word-form-variation-section.tsx
+++ b/client/component/compound/edit-word-form/edit-word-form-variation-section.tsx
@@ -60,8 +60,8 @@ export const EditWordFormVariationSection = create(
         <h4 styleName="heading">{trans("heading.variations")}</h4>
         <div styleName="list">
           {(variations.length > 0) ? (
-            <SwapAnimationContext values={variations} setValues={setVariations}>
-              <EditWordFormDndContext values={variations} setValues={setVariations}>
+            <SwapAnimationContext values={variations} setValues={setVariations} move={variationFieldArraySpec.move}>
+              <EditWordFormDndContext values={variations} setValues={setVariations} move={variationFieldArraySpec.move}>
                 {variations.map((variation, index) => (
                   <EditWordFormVariationItem
                     styleName="item"

--- a/client/util/swap-animation.tsx
+++ b/client/util/swap-animation.tsx
@@ -23,10 +23,12 @@ const SwapAnimationContextProvider = swapAnimationContext["Provider"];
 export const SwapAnimationContext = function <T extends {id: string}>({
   values,
   setValues,
+  move,
   children
 }: {
   values: Array<T>,
   setValues: (update: (values: Array<T>) => Array<T>) => void,
+  move?: (fromIndex: number, toIndex: number) => void,
   children: ReactNode
 }): ReactElement {
   const refs = useRef<Map<string, HTMLElement>>(new Map());
@@ -47,10 +49,14 @@ export const SwapAnimationContext = function <T extends {id: string}>({
       });
       setTimeout(() => {
         setStyles({});
-        setValues((values) => moveArrayItem(values, fromIndex, toIndex));
+        if (move) {
+          move(fromIndex, toIndex);
+        } else {
+          setValues((values) => moveArrayItem(values, fromIndex, toIndex));
+        }
       }, 200);
     }
-  }, [values, setValues]);
+  }, [values, setValues, move]);
   return (
     <SwapAnimationContextProvider value={{values, refs, styles, moveValue}}>
       {children}


### PR DESCRIPTION
Ensures reordering in EditWordForm reliably updates form state by using `useFieldArray().move`.

Previously, reordering items in `EditWordForm` (e.g., equivalents, sections) would visually animate but sometimes fail to persist the new order in the `react-hook-form` state, leading to the order reverting. This was due to `SwapAnimationContext` and `EditWordFormDndContext` only updating local arrays. This PR resolves it by passing `useFieldArray().move` directly to these contexts, ensuring the form's internal state is correctly updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd62d292-5af8-4793-856d-484a2dbcb927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd62d292-5af8-4793-856d-484a2dbcb927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

