### PR TITLE
共同編集者の管理を独立した members コレクションに移行

### DIFF
--- a/document/migration.md
+++ b/document/migration.md
@@ -162,3 +162,19 @@ db.users.find({"apiKey": {$exists: true, $ne: null}}).forEach(function (user) {
   });
 });
 ```
+
+### → ver 3.26.0
+辞書の共同編集者を、辞書ドキュメントの `editUsers` フィールドではなく、独立した `members` コレクションで管理するように変更しました。
+既存の `editUsers` を新しいコレクションに移行するため、Mongo Shell で該当のデータベースを選択した後、以下を実行してください。
+```js
+db.dictionaries.find({"editUsers": {$exists: true}}).forEach(function (dictionary) {
+  (dictionary.editUsers || []).forEach(function (userId) {
+    db.members.insertOne({
+      "dictionary": dictionary._id,
+      "user": userId,
+      "authority": "edit"
+    });
+  });
+});
+db.dictionaries.updateMany({}, {$unset: {"editUsers": ""}});
+```

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -117,15 +117,20 @@ export class DictionarySchema extends DiscardableSchema {
    * `me` に `null` を指定すると、ユーザーに関わらず全員が見ることのできる辞書のみを返します (公開範囲が限定公開以下のものは除外される)。*/
   public static async fetchByUser(user: User, authority: DictionaryAuthority, me: Pick<User, "id"> | null): Promise<Array<Dictionary>> {
     const meDictionaryIds = (me !== null) ? await MemberModel.fetchDictionaryIdsByUser(me, "edit") : [];
+    const visibleFilters = [
+      {"visibility": "public"},
+      {"user": me},
+      DictionaryModel.find().where("_id").in(meDictionaryIds).getFilter()
+    ];
     if (authority === "own") {
-      const query = DictionaryModel.findExist().where({"user": user}).or([{"visibility": "public"}, {"user": me}, {"_id": {"$in": meDictionaryIds}}]).sort({"updatedDate": -1, "number": -1});
+      const query = DictionaryModel.findExist().where({"user": user}).or(visibleFilters).sort({"updatedDate": -1, "number": -1});
       const dictionaries = await query.exec();
       return dictionaries;
     } else {
       const userDictionaryIds = await MemberModel.fetchDictionaryIdsByUser(user, "edit");
       const query = DictionaryModel.findExist().or([
-        DictionaryModel.find({"user": user}).or([{"visibility": "public"}, {"user": me}, {"_id": {"$in": meDictionaryIds}}]).getFilter(),
-        DictionaryModel.find({"_id": {"$in": userDictionaryIds}}).or([{"visibility": "public"}, {"user": me}, {"_id": {"$in": meDictionaryIds}}]).getFilter()
+        DictionaryModel.find({"user": user}).or(visibleFilters).getFilter(),
+        DictionaryModel.find().where("_id").in(userDictionaryIds).or(visibleFilters).getFilter()
       ]).sort({"updatedDate": -1, "number": -1});
       const dictionaries = await query.exec();
       return dictionaries;

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -503,9 +503,9 @@ export class DictionarySchema extends DiscardableSchema {
           if (authority === "own") {
             return this.user.id === user.id;
           } else if (authority === "edit") {
-            return this.user.id === user.id || await MemberModel.existsMember(this, user, "edit");
+            return this.user.id === user.id || await MemberModel.existMember(this, user, "edit");
           } else if (authority === "view") {
-            return (this.visibility === "public" || this.visibility === "unlisted") || this.user.id === user.id || await MemberModel.existsMember(this, user, "edit");
+            return this.user.id === user.id || (this.visibility === "public" || this.visibility === "unlisted") || await MemberModel.existMember(this, user, "edit");
           } else {
             authority satisfies never;
             throw new Error("cannot happen");

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -120,7 +120,7 @@ export class DictionarySchema extends DiscardableSchema {
     const visibleFilters = [
       {"visibility": "public"},
       {"user": me},
-      DictionaryModel.find().where("_id").in(meDictionaryIds).getFilter()
+      DictionaryModel.find().in("_id", meDictionaryIds).getFilter()
     ];
     if (authority === "own") {
       const query = DictionaryModel.findExist().where({"user": user}).or(visibleFilters).sort({"updatedDate": -1, "number": -1});
@@ -130,7 +130,7 @@ export class DictionarySchema extends DiscardableSchema {
       const userDictionaryIds = await MemberModel.fetchDictionaryIdsByUser(user, "edit");
       const query = DictionaryModel.findExist().or([
         DictionaryModel.find({"user": user}).or(visibleFilters).getFilter(),
-        DictionaryModel.find().where("_id").in(userDictionaryIds).or(visibleFilters).getFilter()
+        DictionaryModel.find().in("_id", userDictionaryIds).or(visibleFilters).getFilter()
       ]).sort({"updatedDate": -1, "number": -1});
       const dictionaries = await query.exec();
       return dictionaries;

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -5,7 +5,6 @@ import {
   Ref,
   getModelForClass,
   isDocument,
-  isDocumentArray,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -16,6 +15,7 @@ import {DiscardableSchema} from "/server/model/base";
 import {Deserializer} from "/server/model/dictionary/deserializer";
 import {DICTIONARY_AUTHORITIES, DictionaryAuthority, DictionaryAuthorityQuery, DictionaryAuthorityUtil} from "/server/model/dictionary/dictionary-authority";
 import {DictionarySettings, DictionarySettingsModel, DictionarySettingsSchema} from "/server/model/dictionary/dictionary-settings";
+import {MemberModel} from "/server/model/dictionary/member";
 import {Serializer} from "/server/model/dictionary/serializer";
 import {DictionaryParameter} from "/server/model/dictionary-parameter/dictionary-parameter";
 import {CustomError} from "/server/model/error";
@@ -51,9 +51,6 @@ export class DictionarySchema extends DiscardableSchema {
   @prop({required: true, ref: "UserSchema"})
   public user!: Ref<UserSchema>;
 
-  @prop({required: true, ref: "UserSchema"})
-  public editUsers!: Array<Ref<UserSchema>>;
-
   @prop({required: true, unique: true})
   public number!: number;
 
@@ -84,7 +81,6 @@ export class DictionarySchema extends DiscardableSchema {
   public static async addEmpty(name: string, user: User): Promise<Dictionary> {
     const dictionary = new DictionaryModel({
       user,
-      editUsers: new Array<User>(),
       number: await DictionaryModel.fetchNextNumber(),
       name,
       status: "ready",
@@ -120,14 +116,16 @@ export class DictionarySchema extends DiscardableSchema {
    * `me` にユーザーを指定すると、`me` が見ることのできる辞書のみを返します。
    * `me` に `null` を指定すると、ユーザーに関わらず全員が見ることのできる辞書のみを返します (公開範囲が限定公開以下のものは除外される)。*/
   public static async fetchByUser(user: User, authority: DictionaryAuthority, me: Pick<User, "id"> | null): Promise<Array<Dictionary>> {
+    const meDictionaryIds = (me !== null) ? await MemberModel.fetchDictionaryIdsByUser(me, "edit") : [];
     if (authority === "own") {
-      const query = DictionaryModel.findExist().where({"user": user}).or([{"visibility": "public"}, {"user": me}, {"editUsers": me}]).sort({"updatedDate": -1, "number": -1});
+      const query = DictionaryModel.findExist().where({"user": user}).or([{"visibility": "public"}, {"user": me}, {"_id": {"$in": meDictionaryIds}}]).sort({"updatedDate": -1, "number": -1});
       const dictionaries = await query.exec();
       return dictionaries;
     } else {
+      const userDictionaryIds = await MemberModel.fetchDictionaryIdsByUser(user, "edit");
       const query = DictionaryModel.findExist().or([
-        DictionaryModel.find({"user": user}).or([{"visibility": "public"}, {"user": me}, {"editUsers": me}]).getFilter(),
-        DictionaryModel.find({"editUsers": user}).or([{"visibility": "public"}, {"user": me}, {"editUsers": me}]).getFilter()
+        DictionaryModel.find({"user": user}).or([{"visibility": "public"}, {"user": me}, {"_id": {"$in": meDictionaryIds}}]).getFilter(),
+        DictionaryModel.find({"_id": {"$in": userDictionaryIds}}).or([{"visibility": "public"}, {"user": me}, {"_id": {"$in": meDictionaryIds}}]).getFilter()
       ]).sort({"updatedDate": -1, "number": -1});
       const dictionaries = await query.exec();
       return dictionaries;
@@ -495,15 +493,15 @@ export class DictionarySchema extends DiscardableSchema {
    * `user` が `null` の場合は、匿名ユーザー (限定公開以上の辞書に対して閲覧権限のみがある) として扱います。 */
   public async hasAuthority(this: Dictionary, user: User | null, authority: DictionaryAuthority): Promise<boolean> {
     if (user !== null) {
-      await this.populate(["user", "editUsers"]);
-      if (isDocument(this.user) && isDocumentArray(this.editUsers)) {
+      await this.populate("user");
+      if (isDocument(this.user)) {
         if (user.authority !== "admin") {
           if (authority === "own") {
             return this.user.id === user.id;
           } else if (authority === "edit") {
-            return this.user.id === user.id || this.editUsers.find((editUser) => editUser.id === user.id) !== undefined;
+            return this.user.id === user.id || await MemberModel.existsMember(this, user, "edit");
           } else if (authority === "view") {
-            return (this.visibility === "public" || this.visibility === "unlisted") || this.user.id === user.id || this.editUsers.find((editUser) => editUser.id === user.id) !== undefined;
+            return (this.visibility === "public" || this.visibility === "unlisted") || this.user.id === user.id || await MemberModel.existsMember(this, user, "edit");
           } else {
             authority satisfies never;
             throw new Error("cannot happen");
@@ -535,27 +533,21 @@ export class DictionarySchema extends DiscardableSchema {
   }
 
   public async fetchAuthorizedUsers(this: Dictionary, authorityQuery: DictionaryAuthorityQuery): Promise<Array<User>> {
-    await this.populate(["user", "editUsers"]);
-    if (isDocument(this.user) && isDocumentArray(this.editUsers)) {
+    await this.populate("user");
+    if (isDocument(this.user)) {
       const authority = authorityQuery.authority;
-      if (authorityQuery.exact) {
-        if (authority === "own") {
-          return [this.user];
-        } else if (authority === "edit") {
-          return this.editUsers;
+      if (authority === "own") {
+        return [this.user];
+      } else if (authority === "edit") {
+        const editUsers = await MemberModel.fetchUsersByDictionary(this, "edit");
+        if (authorityQuery.exact) {
+          return editUsers;
         } else {
-          authority satisfies never;
-          throw new Error("cannot happen");
+          return [this.user, ...editUsers];
         }
       } else {
-        if (authority === "own") {
-          return [this.user];
-        } else if (authority === "edit") {
-          return [this.user, ...this.editUsers];
-        } else {
-          authority satisfies never;
-          throw new Error("cannot happen");
-        }
+        authority satisfies never;
+        throw new Error("cannot happen");
       }
     } else {
       throw new Error("cannot happen");
@@ -563,18 +555,11 @@ export class DictionarySchema extends DiscardableSchema {
   }
 
   public async discardAuthorizedUser(this: Dictionary, user: User): Promise<true> {
-    await this.populate("editUsers");
-    if (isDocumentArray(this.editUsers)) {
-      const exist = this.editUsers.find((editUser) => editUser.id === user.id) !== undefined;
-      if (exist) {
-        this.editUsers = this.editUsers.filter((editUser) => editUser.id !== user.id);
-        await this.save();
-        return true;
-      } else {
-        throw new CustomError("noSuchDictionaryAuthorizedUser");
-      }
+    const existed = await MemberModel.discard(this, user);
+    if (existed) {
+      return true;
     } else {
-      throw new Error("cannot happen");
+      throw new CustomError("noSuchDictionaryAuthorizedUser");
     }
   }
 

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -115,25 +115,24 @@ export class DictionarySchema extends DiscardableSchema {
   /** 指定されたユーザーが指定された権限をもっている辞書を全て返します。
    * `me` にユーザーを指定すると、`me` が見ることのできる辞書のみを返します。
    * `me` に `null` を指定すると、ユーザーに関わらず全員が見ることのできる辞書のみを返します (公開範囲が限定公開以下のものは除外される)。*/
-  public static async fetchByUser(user: User, authority: DictionaryAuthority, me: Pick<User, "id"> | null): Promise<Array<Dictionary>> {
+  public static async fetchByUser(user: User, authority: Exclude<DictionaryAuthority, "view">, me: Pick<User, "id"> | null): Promise<Array<Dictionary>> {
     const meDictionaryIds = (me !== null) ? await MemberModel.fetchDictionaryIdsByUser(me, "edit") : [];
-    const visibleFilters = [
-      {"visibility": "public"},
-      {"user": me},
-      DictionaryModel.find().in("_id", meDictionaryIds).getFilter()
-    ];
+    const visibleFilters = [{"visibility": "public"}, {"user": me}, DictionaryModel.find().in("_id", meDictionaryIds).getFilter()];
     if (authority === "own") {
-      const query = DictionaryModel.findExist().where({"user": user}).or(visibleFilters).sort({"updatedDate": -1, "number": -1});
-      const dictionaries = await query.exec();
+      const query = DictionaryModel.findExist().where("user", user).or(visibleFilters);
+      const dictionaries = await query.sort({"updatedDate": -1, "number": -1}).exec();
       return dictionaries;
-    } else {
+    } else if (authority === "edit") {
       const userDictionaryIds = await MemberModel.fetchDictionaryIdsByUser(user, "edit");
       const query = DictionaryModel.findExist().or([
-        DictionaryModel.find({"user": user}).or(visibleFilters).getFilter(),
+        DictionaryModel.find().where("user", user).or(visibleFilters).getFilter(),
         DictionaryModel.find().in("_id", userDictionaryIds).or(visibleFilters).getFilter()
-      ]).sort({"updatedDate": -1, "number": -1});
-      const dictionaries = await query.exec();
+      ]);
+      const dictionaries = await query.sort({"updatedDate": -1, "number": -1}).exec();
       return dictionaries;
+    } else {
+      authority satisfies never;
+      throw new Error("cannot happen");
     }
   }
 

--- a/server/model/dictionary/member-authority.ts
+++ b/server/model/dictionary/member-authority.ts
@@ -1,0 +1,8 @@
+//
+
+import {LiteralType, LiteralUtilType} from "/server/util/literal-type";
+
+
+export const MEMBER_AUTHORITIES = ["edit"] as const;
+export type MemberAuthority = LiteralType<typeof MEMBER_AUTHORITIES>;
+export const MemberAuthorityUtil = LiteralUtilType.create(MEMBER_AUTHORITIES);

--- a/server/model/dictionary/member.ts
+++ b/server/model/dictionary/member.ts
@@ -28,39 +28,32 @@ export class MemberSchema {
   @prop()
   public createdDate?: Date;
 
-  /** 指定された辞書に指定されたユーザーをメンバーとして追加します。
-   * 既に同じ権限のメンバーとして登録されている場合は、何もしません。*/
   public static async add(dictionary: Dictionary, user: User, authority: MemberAuthority): Promise<void> {
-    const exists = await MemberModel.existsMember(dictionary, user, authority);
-    if (!exists) {
+    const exist = await MemberModel.existMember(dictionary, user, authority);
+    if (!exist) {
       const member = new MemberModel({dictionary, user, authority, createdDate: new Date()});
       await member.save();
     }
   }
 
-  /** 指定された辞書から、指定されたユーザーのメンバー登録を全て削除します。
-   * 削除されたメンバーが存在したかどうかを返します。*/
   public static async discard(dictionary: Dictionary, user: User): Promise<boolean> {
     const result = await MemberModel.deleteMany({}).where("dictionary", dictionary).where("user", user);
-    const existed = result.deletedCount > 0;
-    return existed;
+    const exist = result.deletedCount > 0;
+    return exist;
   }
 
-  /** 指定された辞書・ユーザー・権限に合致するメンバーが存在するかどうかを判定します。*/
-  public static async existsMember(dictionary: Dictionary, user: User, authority: MemberAuthority): Promise<boolean> {
+  public static async existMember(dictionary: Dictionary, user: User, authority: MemberAuthority): Promise<boolean> {
     const count = await MemberModel.countDocuments().where("dictionary", dictionary).where("user", user).where("authority", authority);
-    const exists = count > 0;
-    return exists;
+    const exist = count > 0;
+    return exist;
   }
 
-  /** 指定された辞書に属する、指定された権限をもつメンバーのユーザーを全て返します。*/
   public static async fetchUsersByDictionary(dictionary: Dictionary, authority: MemberAuthority): Promise<Array<User>> {
     const members = await MemberModel.find().where("dictionary", dictionary).where("authority", authority).populate("user");
     const users = members.flatMap((member) => (isDocument(member.user)) ? [member.user] : []);
     return users;
   }
 
-  /** 指定されたユーザーが指定された権限をもつメンバーとして属している辞書の ID を全て返します。*/
   public static async fetchDictionaryIdsByUser(user: Pick<User, "id">, authority: MemberAuthority): Promise<Array<Ref<DictionarySchema>>> {
     const members = await MemberModel.find().where("user", user).where("authority", authority).select("dictionary");
     const dictionaryIds = members.map((member) => member.dictionary);

--- a/server/model/dictionary/member.ts
+++ b/server/model/dictionary/member.ts
@@ -1,0 +1,74 @@
+//
+
+import {
+  DocumentType,
+  Ref,
+  getModelForClass,
+  isDocument,
+  modelOptions,
+  prop
+} from "@typegoose/typegoose";
+import {Dictionary, DictionarySchema} from "/server/model/dictionary/dictionary";
+import {MEMBER_AUTHORITIES, MemberAuthority} from "/server/model/dictionary/member-authority";
+import {User, UserSchema} from "/server/model/user/user";
+
+
+@modelOptions({schemaOptions: {collection: "members"}})
+export class MemberSchema {
+
+  @prop({required: true, ref: "DictionarySchema"})
+  public dictionary!: Ref<DictionarySchema>;
+
+  @prop({required: true, ref: "UserSchema"})
+  public user!: Ref<UserSchema>;
+
+  @prop({required: true, enum: MEMBER_AUTHORITIES})
+  public authority!: MemberAuthority;
+
+  @prop()
+  public createdDate?: Date;
+
+  /** 指定された辞書に指定されたユーザーをメンバーとして追加します。
+   * 既に同じ権限のメンバーとして登録されている場合は、何もしません。*/
+  public static async add(dictionary: Dictionary, user: User, authority: MemberAuthority): Promise<void> {
+    const exists = await MemberModel.existsMember(dictionary, user, authority);
+    if (!exists) {
+      const member = new MemberModel({dictionary, user, authority, createdDate: new Date()});
+      await member.save();
+    }
+  }
+
+  /** 指定された辞書から、指定されたユーザーのメンバー登録を全て削除します。
+   * 削除されたメンバーが存在したかどうかを返します。*/
+  public static async discard(dictionary: Dictionary, user: User): Promise<boolean> {
+    const result = await MemberModel.deleteMany({}).where("dictionary", dictionary).where("user", user);
+    const existed = result.deletedCount > 0;
+    return existed;
+  }
+
+  /** 指定された辞書・ユーザー・権限に合致するメンバーが存在するかどうかを判定します。*/
+  public static async existsMember(dictionary: Dictionary, user: User, authority: MemberAuthority): Promise<boolean> {
+    const count = await MemberModel.countDocuments().where("dictionary", dictionary).where("user", user).where("authority", authority);
+    const exists = count > 0;
+    return exists;
+  }
+
+  /** 指定された辞書に属する、指定された権限をもつメンバーのユーザーを全て返します。*/
+  public static async fetchUsersByDictionary(dictionary: Dictionary, authority: MemberAuthority): Promise<Array<User>> {
+    const members = await MemberModel.find().where("dictionary", dictionary).where("authority", authority).populate("user");
+    const users = members.flatMap((member) => (isDocument(member.user)) ? [member.user] : []);
+    return users;
+  }
+
+  /** 指定されたユーザーが指定された権限をもつメンバーとして属している辞書の ID を全て返します。*/
+  public static async fetchDictionaryIdsByUser(user: Pick<User, "id">, authority: MemberAuthority): Promise<Array<Ref<DictionarySchema>>> {
+    const members = await MemberModel.find().where("user", user).where("authority", authority).select("dictionary");
+    const dictionaryIds = members.map((member) => member.dictionary);
+    return dictionaryIds;
+  }
+
+}
+
+
+export type Member = DocumentType<MemberSchema>;
+export const MemberModel = getModelForClass(MemberSchema);

--- a/server/model/index.ts
+++ b/server/model/index.ts
@@ -5,6 +5,8 @@ export * from "./dictionary/serializer";
 export * from "./dictionary/dictionary-authority";
 export * from "./dictionary/dictionary-font";
 export * from "./dictionary/dictionary-settings";
+export * from "./dictionary/member-authority";
+export * from "./dictionary/member";
 export * from "./dictionary/dictionary";
 export * from "./dictionary-parameter/dictionary-parameter";
 export * from "./dictionary-parameter/normal-dictionary-parameter";

--- a/server/model/invitation.ts
+++ b/server/model/invitation.ts
@@ -5,11 +5,11 @@ import {
   Ref,
   getModelForClass,
   isDocument,
-  isDocumentArray,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
 import {Dictionary, DictionarySchema} from "/server/model/dictionary/dictionary";
+import {MemberModel} from "/server/model/dictionary/member";
 import {CustomError} from "/server/model/error";
 import {User, UserSchema} from "/server/model/user/user";
 import {LiteralType, LiteralUtilType} from "/server/util/literal-type";
@@ -94,20 +94,19 @@ export class InvitationSchema {
   private async respondEdit(this: Invitation, user: User): Promise<void> {
     await this.populate("dictionary");
     if (isDocument(this.dictionary)) {
-      this.dictionary.editUsers = [...this.dictionary.editUsers, user];
-      await this.dictionary.save();
+      await MemberModel.add(this.dictionary, user, "edit");
     }
   }
 
   private async respondTransfer(this: Invitation, user: User): Promise<void> {
     await this.populate("dictionary");
     if (isDocument(this.dictionary)) {
-      await this.dictionary.populate(["user", "editUsers"]);
-      if (isDocument(this.dictionary.user) && isDocumentArray(this.dictionary.editUsers)) {
+      await this.dictionary.populate("user");
+      if (isDocument(this.dictionary.user)) {
         const previousUser = this.dictionary.user;
-        const nextEditUsers = this.dictionary.editUsers.filter((editUser) => editUser.id !== user.id && editUser.id !== previousUser.id);
+        await MemberModel.discard(this.dictionary, user);
+        await MemberModel.add(this.dictionary, previousUser, "edit");
         this.dictionary.user = user;
-        this.dictionary.editUsers = [...nextEditUsers, previousUser];
         await this.dictionary.save();
       }
     }


### PR DESCRIPTION
## 概要
辞書の共同編集者 (メンバー) を `DictionarySchema.editUsers` 埋め込み配列ではなく、独立した `members` コレクション (`MemberSchema`) で管理するように改修しました。今後の権限管理の拡張に備えるための変更です。

**API 契約 (skeleton / ServerSpecs) に変更はなく、フロントから見た挙動は不変**です。サーバー内部の処理のみが変わります。

## 変更内容

### 新規ファイル
- `server/model/dictionary/member-authority.ts` — `MemberAuthority` 列挙型 (一旦 `"edit"` のみ) を既存の `LiteralType` / `LiteralUtilType` パターンで定義。
- `server/model/dictionary/member.ts` — 独立コレクション `members` をもつ `MemberSchema`。フィールドは `dictionary` (ref) / `user` (ref) / `authority` / `createdDate` (optional)。ドメインロジックを static メソッドに集約:
  - `add` / `discard` — メンバー追加 (重複は無視) ・削除
  - `existsMember` — 権限判定用
  - `fetchUsersByDictionary` — 辞書のメンバーのユーザー一覧
  - `fetchDictionaryIdsByUser` — あるユーザーがメンバーである辞書 ID 一覧 (`fetchByUser` のクエリ用)

### 改修ファイル
- `server/model/dictionary/dictionary.ts` — `editUsers` プロパティと `addEmpty` での初期化を削除。`hasAuthority` / `fetchAuthorizedUsers` / `discardAuthorizedUser` / `fetchByUser` を `MemberModel` 経由に書き換え。`fetchByUser` の旧 `{"editUsers": x}` クエリは、メンバーコレクションから取得した辞書 ID による `{"_id": {$in: ...}}` に置換し、可視性条件の構造は元のまま維持。
- `server/model/invitation.ts` — `respondEdit` (編集者追加) と `respondTransfer` (所有権移譲: 新所有者をメンバーから外し、旧所有者をメンバー化) を `MemberModel` ベースに変更。
- `server/model/index.ts` — 新モデルを export。
- `document/migration.md` — ver 3.26.0 として、既存 `editUsers` を `members` コレクションへ移行 (`authority: "edit"`) し `editUsers` フィールドを削除するコマンドを追記。

## 設計上のメモ
- `own` (`DictionarySchema.user`) と `view` (公開範囲) は従来どおり別扱いで、メンバー化されるのは編集者 (`edit`) のみ。`DictionaryAuthority` とは別物の `MemberAuthority` を新設。
- マイグレーションは削除される `editUsers` を移行対象としています (所有者 `user` は辞書側に残り、メンバーにはしない設計のため)。

## 確認事項
- ESLint: 変更ファイルでエラーなし。
- 型チェック: サーバーソースに型エラーなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)