### PR TITLE
discardMember API を member の id で受け取るように変更

### DIFF
--- a/client/component/compound/member-list/member-card.tsx
+++ b/client/component/compound/member-list/member-card.tsx
@@ -25,7 +25,7 @@ export const MemberCard = create(
     const {trans} = useTrans("memberList");
 
     const user = member.user;
-    const discardMember = useDiscardMember(dictionary, user);
+    const discardMember = useDiscardMember(dictionary, member);
 
     return (
       <Card styleName="root" {...rest}>

--- a/client/component/compound/member-list/member-list-hook.ts
+++ b/client/component/compound/member-list/member-list-hook.ts
@@ -7,23 +7,23 @@ import {useCommonAlert} from "/client/component/atom/common-alert";
 import {invalidateResponses, useRequest} from "/client/hook/request";
 import {useToast} from "/client/hook/toast";
 import {switchResponse} from "/client/util/response";
-import {Dictionary, User} from "/server/internal/skeleton";
+import {Dictionary, Member} from "/server/internal/skeleton";
 
 
-export function useDiscardMember(dictionary: Dictionary, user: User): () => void {
+export function useDiscardMember(dictionary: Dictionary, member: Member): () => void {
   const {trans} = useTrans("memberList");
   const request = useRequest();
   const openAlert = useCommonAlert();
   const {dispatchSuccessToast} = useToast();
   const doRequest = useCallback(async function (): Promise<void> {
     const number = dictionary.number;
-    const id = user.id;
+    const id = member.id;
     const response = await request("discardMember", {number, id});
     await switchResponse(response, async () => {
       await invalidateResponses("fetchMembers", (query) => query.number === dictionary.number);
       dispatchSuccessToast("discardMember");
     });
-  }, [dictionary.number, user.id, request, dispatchSuccessToast]);
+  }, [dictionary.number, member.id, request, dispatchSuccessToast]);
   const execute = useCallback(function (): void {
     openAlert({
       message: trans("dialog.discard.message"),

--- a/server/internal/controller/rest/dictionary.ts
+++ b/server/internal/controller/rest/dictionary.ts
@@ -72,16 +72,11 @@ export class DictionaryRestController extends InternalRestController {
   public async [Symbol()](request: FilledRequest<"discardMember", "me" | "dictionary">, response: Response<"discardMember">): Promise<void> {
     const {dictionary} = request.middlewareBody;
     const {id} = request.body;
-    const user = await UserModel.findById(id);
-    if (user) {
-      try {
-        await dictionary.discardMember(user);
-        InternalRestController.respond(response, null);
-      } catch (error) {
-        InternalRestController.respondByCustomError(response, ["noSuchMember"], error);
-      }
-    } else {
-      InternalRestController.respondError(response, "noSuchMember");
+    try {
+      await dictionary.discardMember(id);
+      InternalRestController.respond(response, null);
+    } catch (error) {
+      InternalRestController.respondByCustomError(response, ["noSuchMember"], error);
     }
   }
 

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -541,8 +541,8 @@ export class DictionarySchema extends DiscardableSchema {
     return members;
   }
 
-  public async discardMember(this: Dictionary, user: User): Promise<void> {
-    await MemberModel.discard(this, user);
+  public async discardMember(this: Dictionary, id: string): Promise<void> {
+    await MemberModel.discard(this, id);
   }
 
   private static async fetchNextNumber(): Promise<number> {

--- a/server/model/member/member.ts
+++ b/server/model/member/member.ts
@@ -36,8 +36,8 @@ export class MemberSchema {
     }
   }
 
-  public static async discard(dictionary: Dictionary, user: User): Promise<void> {
-    const member = await MemberModel.findOne().where("dictionary", dictionary).where("user", user);
+  public static async discard(dictionary: Dictionary, id: string): Promise<void> {
+    const member = await MemberModel.findById(id).where("dictionary", dictionary);
     if (member !== null) {
       await member.deleteOne();
     } else {


### PR DESCRIPTION
`discardMember` API が受け取る `id` を、対象ユーザーの id ではなく **Member ドキュメントの id** に変更しました。`fetchMembers` が `Member` を返すようになったことに合わせ、リソースを自身の id で指定する素直な形にします。

## 変更内容

### サーバー
- **`MemberModel.discard(dictionary, id)`** — `(dictionary, user)` ではなく `(dictionary, memberId)` を受け取り、**`_id` + `dictionary` の両方で検索**して削除（なければ `noSuchMember`）。
- **`DictionarySchema.discardMember(id)`** — member の id を受け取る薄い委譲に変更。
- **controller** — `UserModel.findById` のルックアップを除去し、`id` をそのまま `discardMember` へ渡す。

### フロント
- **`useDiscardMember(dictionary, member)`** — `user` ではなく `member` を受け取り、`member.id` を送信。
- **`MemberCard`** — フックに `member` を渡すよう変更。

## スコープ担保（重要）
`checkDictionary(\"own\")` が認可するのは `number` で指定された辞書のみです。member の id を素朴に `findById` で引くと、他辞書に属する member の id を渡して削除できてしまうため、**`findById(id).where(\"dictionary\", dictionary)`** として認可済み辞書に属する member のみを対象にしています。これにより、別辞書の member を誤って（または不正に）削除することを防ぎます。

## 確認
- ESLint: エラーなし
- 型チェック（client/server ソース）: エラーなし
- API 契約は `{number, id}` のまま（`id` の意味が user id → member id に変わるのみ）。フロントの送信値も合わせて変更済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)