### PR TITLE
メッセージファイル整備: 20260630

### DIFF
--- a/client/message/en.yml
+++ b/client/message/en.yml
@@ -243,6 +243,13 @@ toast:
 commonAlert:
   confirm: "Confirm"
   cancel: "Cancel"
+exampleModeSelect:
+  label:
+    sentence: "Sentence"
+    translation: "Translation"
+    both: "Both"
+    tag: "Tag"
+    content: "Whole"
 exampleOfferTag:
   catalog:
     zpdicDaily: "Daily sentences"
@@ -257,13 +264,6 @@ exampleOfferTag:
     arithmetic: "Arithmetic sentences"
     adposition: "Sentences for cases and adpositions"
   number: "#{number, number}"
-exampleModeSelect:
-  label:
-    sentence: "Sentence"
-    translation: "Translation"
-    both: "Both"
-    tag: "Tag"
-    content: "Whole"
 exampleTypeSelect:
   label:
     prefix: "Prefix"
@@ -300,6 +300,27 @@ addProposalDialog:
   error:
     nameRequired: >-
       Enter the word to request.
+apiCredentialList:
+  button:
+    copy: "Copy"
+    discard: "Delete"
+  dialog:
+    discard:
+      message: >-
+        This API key will be deleted.
+        Any programs using this API key will no longer be able to access dictionaries.
+        Are you sure?
+      confirm: "Delete"
+  table:
+    createdDate: "Issued at"
+    lastUsedDate: "Last used at"
+    neverUsed: "Never used"
+  caution: >-
+    Please copy this key now and save it in a safe place, as you will not be able to see it later.
+  empty: "You have not issued any API keys yet"
+  toast:
+    copy: >-
+      Copied your API key.
 articleList:
   empty: "No articles are created"
   button:
@@ -315,17 +336,6 @@ articleList:
       confirm: "Delete"
 changeLocaleForm:
   label: "Language"
-proposalList:
-  empty: "No words are requested"
-  button:
-    add: "Create"
-    discard: "Delete"
-  dialog:
-    discard:
-      message: >-
-        This request will be deleted permanently.
-        Are you really sure?
-      confirm: "Delete"
 contactForm:
   label:
     name: "Name"
@@ -342,16 +352,6 @@ contactForm:
       Enter your message.
     agreeRequired: >-
       Read the privacy policy and agree to it.
-memberList:
-  empty: "No users have editing permission"
-  button:
-    discard: "Revoke"
-  dialog:
-    discard:
-      message: >-
-        The permission of this user will be revoked.
-        Are you really sure?
-      confirm: "Revoke"
 dictionaryHeader:
   tab:
     dictionary: "Dictionary"
@@ -595,6 +595,30 @@ invitationList:
   button:
     accept: "Accept"
     reject: "Decline"
+loginForm:
+  label:
+    name: "Username"
+    password: "Password"
+  button:
+    confirm: "Sign in"
+    register: "Create account"
+    resetPassword: "Reset password"
+  or: "or"
+  error:
+    nameRequired: >-
+      Enter your username.
+    passwordRequired: >-
+      Enter your password.
+memberList:
+  empty: "No users have editing permission"
+  button:
+    discard: "Revoke"
+  dialog:
+    discard:
+      message: >-
+        The permission of this user will be revoked.
+        Are you really sure?
+      confirm: "Revoke"
 notificationList:
   tag:
     update: "Update"
@@ -611,6 +635,64 @@ orderModeSelect:
   custom: "Custom"
   updatedDate: "Update time"
   createdDate: "Creation time"
+proposalList:
+  empty: "No words are requested"
+  button:
+    add: "Create"
+    discard: "Delete"
+  dialog:
+    discard:
+      message: >-
+        This request will be deleted permanently.
+        Are you really sure?
+      confirm: "Delete"
+registerForm:
+  label:
+    name: &label.name "Username"
+    email: &label.email "Email address"
+    password: "Password"
+    agree: "Agree to the <termsLink>terms of service</termsLink> and <privacyLink>privacy policy</privacyLink>"
+  button:
+    confirm: "Create account"
+  error:
+    nameInvalid: >-
+      The username must be composed of alphanumeric characters, underscores and hyphens.
+      It must also contain at least one non-digit.
+    nameTooLong: >-
+      The username must contain no more than 30 characters.
+    nameRequired: &error.nameRequired >-
+      Enter a username.
+    emailInvalid: &error.emailInvalid >-
+      Enter a valid email address.
+    emailRequired: &error.emailRequired >-
+      Enter an email address.
+    passwordTooShort: &error.passwordTooShort >-
+      The password must contain at least 6 characters.
+    passwordTooLong: &error.passwordTooLong >-
+      The password must contain no more than 50 characters.
+    passwordRequired: &error.passwordRequired >-
+      Enter a password.
+    agreeRequired: >-
+      In order to use this application, you must read and agree to the privacy policy.
+issueUserResetTokenForm:
+  label:
+    name: *label.name
+    email: *label.email
+  error:
+    nameRequired: *error.nameRequired
+    emailInvalid: *error.emailInvalid
+    emailRequired: *error.emailRequired
+  button:
+    confirm: "Send"
+resetUserPasswordForm:
+  label:
+    password: "New password"
+  error:
+    tooShort: *error.passwordTooShort
+    tooLong: *error.passwordTooLong
+    required: *error.passwordRequired
+  button:
+    confirm: "Reset"
 resourceList:
   empty: "No images are uploaded"
   button:
@@ -644,6 +726,8 @@ searchWordAdvancedDialog:
     text: "Keyword"
   absent:
     element: "No conditions"
+  discard:
+    equivalent: "<NOT SET>"
   button:
     add:
       element: "Add condition"
@@ -672,6 +756,35 @@ shareMenu:
 suggestionCard:
   maybe: "Do you mean…"
   message: "{title} <mute>of</mute> {nameNode}"
+templateWordList:
+  empty: "No templates are created"
+  button:
+    edit: "Detail · Edit"
+    discard: "Delete"
+  label:
+    equivalent: "Translations ×{count}"
+    information: "Contents ×{count}"
+    phrase: "Idiomatic expressions ×{count}"
+    variation: "Variation forms ×{count}"
+    relation: "Related words ×{count}"
+  dialog:
+    discard:
+      message: >-
+        This template will be deleted permanently.
+        You cannot restore it afterwards.
+        Are you really sure?
+      confirm: "Delete"
+termsAgreementBanner:
+  message:
+    before: >-
+      The new <termsLink>terms of service</termsLink> and <privacyLink>privacy policy</privacyLink> are scheduled to take effect on {dateString}.
+      Please review them, and if you agree, press the ‘Agree’ button.
+      Note that if you continue to use this application on or after {dateString}, you will be deemed to have agreed to them.
+      If you do not agree, please delete your account and export your data before then.
+    after: >-
+      The new <termsLink>terms of service</termsLink> and <privacyLink>privacy policy</privacyLink> have been in effect since {dateString}.
+  button:
+    agree: "Agree"
 userHeader:
   tab:
     dictionary: "Dictionaries"
@@ -710,126 +823,13 @@ wordList:
         You cannot restore it afterwards.
         Are you really sure?
       confirm: "Delete"
-templateWordList:
-  empty: "No templates are created"
-  button:
-    edit: "Detail · Edit"
-    discard: "Delete"
-  label:
-    equivalent: "Translations ×{count}"
-    information: "Contents ×{count}"
-    phrase: "Idiomatic expressions ×{count}"
-    variation: "Variation forms ×{count}"
-    relation: "Related words ×{count}"
-  dialog:
-    discard:
-      message: >-
-        This template will be deleted permanently.
-        You cannot restore it afterwards.
-        Are you really sure?
-      confirm: "Delete"
 wordNameFrequencyChart:
   other: "Others"
 wordPopover:
   button:
     edit: "Edit"
-loginForm:
-  label:
-    name: "Username"
-    password: "Password"
-  button:
-    confirm: "Sign in"
-    register: "Create account"
-    resetPassword: "Reset password"
-  or: "or"
-  error:
-    nameRequired: >-
-      Enter your username.
-    passwordRequired: >-
-      Enter your password.
-registerForm:
-  label:
-    name: &label.name "Username"
-    email: &label.email "Email address"
-    password: "Password"
-    agree: "Agree to the <termsLink>terms of service</termsLink> and <privacyLink>privacy policy</privacyLink>"
-  button:
-    confirm: "Create account"
-  error:
-    nameInvalid: >-
-      The username must be composed of alphanumeric characters, underscores and hyphens.
-      It must also contain at least one non-digit.
-    nameTooLong: >-
-      The username must contain no more than 30 characters.
-    nameRequired: &error.nameRequired >-
-      Enter a username.
-    emailInvalid: &error.emailInvalid >-
-      Enter a valid email address.
-    emailRequired: &error.emailRequired >-
-      Enter an email address.
-    passwordTooShort: &error.passwordTooShort >-
-      The password must contain at least 6 characters.
-    passwordTooLong: &error.passwordTooLong >-
-      The password must contain no more than 50 characters.
-    passwordRequired: &error.passwordRequired >-
-      Enter a password.
-    agreeRequired: >-
-      In order to use this application, you must read and agree to the privacy policy.
-termsAgreementBanner:
-  message:
-    before: >-
-      The new <termsLink>terms of service</termsLink> and <privacyLink>privacy policy</privacyLink> are scheduled to take effect on {dateString}.
-      Please review them, and if you agree, press the ‘Agree’ button.
-      Note that if you continue to use this application on or after {dateString}, you will be deemed to have agreed to them.
-      If you do not agree, please delete your account and export your data before then.
-    after: >-
-      The new <termsLink>terms of service</termsLink> and <privacyLink>privacy policy</privacyLink> have been in effect since {dateString}.
-  button:
-    agree: "Agree"
-issueUserResetTokenForm:
-  label:
-    name: *label.name
-    email: *label.email
-  error:
-    nameRequired: *error.nameRequired
-    emailInvalid: *error.emailInvalid
-    emailRequired: *error.emailRequired
-  button:
-    confirm: "Send"
-resetUserPasswordForm:
-  label:
-    password: "New password"
-  error:
-    tooShort: *error.passwordTooShort
-    tooLong: *error.passwordTooLong
-    required: *error.passwordRequired
-  button:
-    confirm: "Reset"
 
 # form
-commonForm:
-  button:
-    change: "Change"
-addEditInvitationButton:
-  heading: "Grant editing permission"
-  label:
-    user: "Grant permission to"
-  button:
-    open: "Grant editing permission"
-    confirm: "Confirm"
-  error:
-    required: >-
-      Select a user.
-addTransferInvitationButton:
-  heading: "Transfer"
-  label:
-    user: "Transfer to"
-  button:
-    open: "Transfer"
-    confirm: "Confirm"
-  error:
-    required: >-
-      Select a user.
 addDictionaryButton:
   heading: "Create new dictionary"
   label:
@@ -840,6 +840,16 @@ addDictionaryButton:
   error:
     required: >-
       Enter a name.
+addEditInvitationButton:
+  heading: "Grant editing permission"
+  label:
+    user: "Grant permission to"
+  button:
+    open: "Grant editing permission"
+    confirm: "Confirm"
+  error:
+    required: >-
+      Select a user.
 addResourceButton:
   heading: "Upload image"
   label:
@@ -853,6 +863,16 @@ addResourceButton:
     tooLarge: >-
       The file is too large.
       You cannot upload files larger than 1 MB.
+addTransferInvitationButton:
+  heading: "Transfer"
+  label:
+    user: "Transfer to"
+  button:
+    open: "Transfer"
+    confirm: "Confirm"
+  error:
+    required: >-
+      Select a user.
 changeAppearanceForm:
   label: 
     font:
@@ -866,17 +886,6 @@ changeAppearanceForm:
       label: "Color theme"
       light: "Light"
       dark: "Dark"
-changeDictionaryNameForm:
-  error:
-    required: >-
-      Enter a name.
-changeDictionaryParamNameForm:
-  error:
-    invalid: >-
-      The identifier must be composed of alphanumeric characters, underscores and hyphens.
-      It must also contain at least one non-digit.
-    tooLong: >-
-      The identifier must contain no more than 30 characters.
 changeDictionaryFontForm:
   label:
     kind:
@@ -961,6 +970,17 @@ changeDictionaryMarkdownFeaturesForm:
       font: >-
         The text enclosed in <pre>'{'</pre> and <pre>'}'</pre> will be displayed in the custom font.
         Please also enable ‘Contents’ in the ‘Custom font’ section above.
+changeDictionaryNameForm:
+  error:
+    required: >-
+      Enter a name.
+changeDictionaryParamNameForm:
+  error:
+    invalid: >-
+      The identifier must be composed of alphanumeric characters, underscores and hyphens.
+      It must also contain at least one non-digit.
+    tooLong: >-
+      The identifier must contain no more than 30 characters.
 changeDictionarySettingsForm:
   label:
     enableAdvancedWord:
@@ -1015,10 +1035,9 @@ changeDictionaryShowNumbersForm:
 changeDictionarySlimeTitlesForm:
   label:
     pronunciation: "For pronunciations"
-changeDictionaryWordCardTitlesForm:
-  label:
-    phrase: "For idiomatic expressions"
-    example: "For example sentences"
+changeDictionarySourceForm:
+  button:
+    try: "Try"
 changeDictionaryVisibilityForm:
   label:
     public: "Public"
@@ -1032,9 +1051,10 @@ changeDictionaryVisibilityForm:
     private: >-
       Only users with editing permission can view this dictionary.
       Users without permission cannot access it even if they know the URL.
-changeDictionarySourceForm:
-  button:
-    try: "Try"
+changeDictionaryWordCardTitlesForm:
+  label:
+    phrase: "For idiomatic expressions"
+    example: "For example sentences"
 changeMyEmailForm:
   error:
     invalid: >-
@@ -1058,6 +1078,9 @@ changeMyScreenNameForm:
   error:
     required: >-
       Enter a nickname.
+commonForm:
+  button:
+    change: "Change"
 discardDictionaryButton:
   button:
     submit: "Delete"
@@ -1067,9 +1090,6 @@ discardDictionaryButton:
       You cannot restore it afterwards.
       Are you really sure?
     confirm: "Delete"
-logoutButton:
-  button:
-    submit: "Sign out"
 discardMeButton:
   button:
     submit: "Delete"
@@ -1079,6 +1099,30 @@ discardMeButton:
       You cannot restore it afterwards.
       Are you really sure?
     confirm: "Delete"
+downloadDictionaryForm:
+  button:
+    download: "Download"
+    back: "Back to dictionary page"
+  message:
+    processing: >-
+      Creating a file.
+    success: >-
+      The file has been created.
+      You can download it from the button below.
+    error: >-
+      Failed to create the file.
+generateMyApiCredentialForm:
+  button:
+    generate: "Generate"
+    copy: "Copy"
+  toast: 
+    copy: >-
+      Copied your API key.
+  caution: >-
+    Please copy this key now and save it in a safe place, as you will not be able to see it later.
+logoutButton:
+  button:
+    submit: "Sign out"
 queueDownloadDictionaryButton:
   heading: "Export"
   label:
@@ -1096,18 +1140,6 @@ queueDownloadDictionaryButton:
   button:
     open: "Export"
     confirm: "Confirm"
-downloadDictionaryForm:
-  button:
-    download: "Download"
-    back: "Back to dictionary page"
-  message:
-    processing: >-
-      Creating a file.
-    success: >-
-      The file has been created.
-      You can download it from the button below.
-    error: >-
-      Failed to create the file.
 queueUploadDictionaryButton:
   heading: "Import"
   label:
@@ -1132,38 +1164,6 @@ uploadDictionaryForm:
       Your file has been imported.
     error: >-
       Failed to import your file.
-generateMyApiCredentialForm:
-  button:
-    generate: "Generate"
-    copy: "Copy"
-  toast: 
-    copy: >-
-      Copied your API key.
-  caution: >-
-    Please copy this key now and save it in a safe place, as you will not be able to see it later.
-
-# compound
-apiCredentialList:
-  button:
-    copy: "Copy"
-    discard: "Delete"
-  dialog:
-    discard:
-      message: >-
-        This API key will be deleted.
-        Any programs using this API key will no longer be able to access dictionaries.
-        Are you sure?
-      confirm: "Delete"
-  table:
-    createdDate: "Issued at"
-    lastUsedDate: "Last used at"
-    neverUsed: "Never used"
-  caution: >-
-    Please copy this key now and save it in a safe place, as you will not be able to see it later.
-  empty: "You have not issued any API keys yet"
-  toast:
-    copy: >-
-      Copied your API key.
 
 # page
 contactPage:
@@ -1177,18 +1177,12 @@ contactPage:
     If your enquiry is a question about the service, you can use this as well.
   disclaimer: |-
     Please note that we may not be able to answer all enquiries directly.
-exampleOfferListPage:
-  title: "Sentences"
-  heading: "Sentences"
 dictionaryArticlePart:
   button:
     addArticle: "Create article"
 dictionaryArticleSinglePart:
   button:
     back: "Back to list"
-dictionaryProposalPart:
-  button:
-    addProposal: "Create request"
 dictionaryExamplePart:
   heading:
     offer: "Today’s sentence"
@@ -1209,18 +1203,13 @@ dictionaryMainPart:
     addWord: "Create word"
     addWordFromTemplate: "Create word from template"
     addProposal: "Request"
+dictionaryProposalPart:
+  button:
+    addProposal: "Create request"
 dictionaryResourcePart:
   explanation: >-
     You can use the uploaded images in the description of the dictionary and the content of words.
     Copy the code below the image and paste it into a text box.
-dictionarySettingPart:
-  tab:
-    general: "General"
-    display: "Display"
-    editing: "Editing"
-    template: "Templates"
-    authority: "Permissions"
-    file: "File"
 dictionarySettingAuthorityPart:
   heading:
     editInvitation: "Editing permission"
@@ -1319,6 +1308,14 @@ dictionarySettingGeneralPart:
     discard: >-
       Deleting this dictionary will also delete all the relevant data, including words and example sentences.
       Please be certain, as there is no going back.
+dictionarySettingPart:
+  tab:
+    general: "General"
+    display: "Display"
+    editing: "Editing"
+    template: "Templates"
+    authority: "Permissions"
+    file: "File"
 dictionarySettingTemplatePart:
   heading:
     templateWords: "Templates"
@@ -1354,6 +1351,9 @@ errorPage:
   button:
     back: "Back to top page"
     refresh: "Refresh page"
+exampleOfferListPage:
+  title: "Sentences"
+  heading: "Sentences"
 examplePage:
   add: "Create new sentence"
 loginPage:

--- a/client/message/en.yml
+++ b/client/message/en.yml
@@ -727,7 +727,7 @@ searchWordAdvancedDialog:
   absent:
     element: "No conditions"
   discard:
-    equivalent: "<NOT SET>"
+    equivalent: "Delete"
   button:
     add:
       element: "Add condition"

--- a/client/message/eo.yml
+++ b/client/message/eo.yml
@@ -243,6 +243,13 @@ toast:
 commonAlert:
   confirm: "Konfirmi"
   cancel: "Nuligi"
+exampleModeSelect:
+  label:
+    sentence: "Frazo"
+    translation: "Tradukaĵo"
+    both: "Ambaŭ"
+    tag: "Etikedo"
+    content: "Tuto"
 exampleOfferTag:
   catalog:
     zpdicDaily: "Ĉiutagaj frazoj"
@@ -257,13 +264,6 @@ exampleOfferTag:
     arithmetic: "Aritmetikaj frazoj"
     adposition: "Frazoj por kazoj kaj adpozicioj"
   number: "#{number, number}"
-exampleModeSelect:
-  label:
-    sentence: "Frazo"
-    translation: "Tradukaĵo"
-    both: "Ambaŭ"
-    tag: "Etikedo"
-    content: "Tuto"
 exampleTypeSelect:
   label:
     prefix: "Prefiksa"
@@ -300,6 +300,27 @@ addProposalDialog:
   error:
     nameRequired: >-
       Enigu la vorton kies kreadon vi petas.
+apiCredentialList:
+  button:
+    copy: "Kopii"
+    discard: "Forigi"
+  dialog:
+    discard:
+      message: >-
+        Tiu API-ŝlosilo estos forigita.
+        Programoj uzantaj tiun API-ŝlosilon ne plu povos aliri vortarojn.
+        Ĉu vi certas?
+      confirm: "Forigi"
+  table:
+    createdDate: "Eldonita je"
+    lastUsedDate: "Laste uzita je"
+    neverUsed: "Neniam uzita"
+  caution: >-
+    Bonvolu kopii tiun ŝlosilon nun kaj savi ĝin en sigura loko, ĉar vi ne povos vidi ĝin poste.
+  empty: "Vi ankoraŭ ne eldonis iun ajn API-ŝlosilon"
+  toast:
+    copy: >-
+      Via API-ŝlosilo estas kopiita.
 articleList:
   empty: "Neniuj artikoloj estas kreitaj"
   button:
@@ -315,17 +336,6 @@ articleList:
       confirm: "Forigi"
 changeLocaleForm:
   label: "Lingvo"
-proposalList:
-  empty: "Neniuj vortoj estas petitaj"
-  button:
-    add: "Krei"
-    discard: "Forigi"
-  dialog:
-    discard:
-      message: >-
-        Tiu peto estos forigita konstante.
-        Ĉu vi vere certas?
-      confirm: "Forigi"
 contactForm:
   label:
     name: "Nomo"
@@ -342,16 +352,6 @@ contactForm:
       Enigu vian mesaĝon.
     agreeRequired: >-
       Legu kaj konsentu pri la privateca politiko.
-memberList:
-  empty: "Neniuj uzantoj havas redaktan permeson"
-  button:
-    discard: "Revoki"
-  dialog:
-    discard:
-      message: >-
-        La permeso de tiu uzanto estos revokita.
-        Ĉu vi vere certas?
-      confirm: "Revoki"
 dictionaryHeader:
   tab:
     dictionary: "Vortaro"
@@ -595,6 +595,30 @@ invitationList:
   button:
     accept: "Akcepti"
     reject: "Malakcepti"
+loginForm:
+  label:
+    name: "Salutnomo"
+    password: "Pasvorto"
+  button:
+    confirm: "Ensaluti"
+    register: "Krei konton"
+    resetPassword: "Restarigi pasvorton"
+  or: "aŭ"
+  error:
+    nameRequired: >-
+      Enigu vian salutnomon.
+    passwordRequired: >-
+      Enigu vian pasvorton.
+memberList:
+  empty: "Neniuj uzantoj havas redaktan permeson"
+  button:
+    discard: "Revoki"
+  dialog:
+    discard:
+      message: >-
+        La permeso de tiu uzanto estos revokita.
+        Ĉu vi vere certas?
+      confirm: "Revoki"
 notificationList:
   tag:
     update: "Ĝisdatigo"
@@ -611,6 +635,64 @@ orderModeSelect:
   custom: "Propra ordo"
   updatedDate: "Ĝisdatigado"
   createdDate: "Kreado"
+proposalList:
+  empty: "Neniuj vortoj estas petitaj"
+  button:
+    add: "Krei"
+    discard: "Forigi"
+  dialog:
+    discard:
+      message: >-
+        Tiu peto estos forigita konstante.
+        Ĉu vi vere certas?
+      confirm: "Forigi"
+registerForm:
+  label:
+    name: &label.name "Salutnomo"
+    email: &label.email "Retpoŝta adreso"
+    password: "Pasvorto"
+    agree: "Konsenti pri la <termsLink>uzkondiĉoj</termsLink> kaj <privacyLink>privateca politiko</privacyLink>"
+  button:
+    confirm: "Krei konton"
+  error:
+    nameInvalid: >-
+      La salutnomo devas ampleksi alfanombraj signoj, substrekoj kaj streketoj.
+      Ĝi ankaŭ devas enhavi almenaŭ unu neciferan signon.
+    nameTooLong: >-
+      La salutnomo devas havi apenaŭ 30 signojn.
+    nameRequired: &error.nameRequired >-
+      Enigu salutnomon.
+    emailInvalid: &error.emailInvalid >-
+      Enigu validan retpoŝtan adreson.
+    emailRequired: &error.emailRequired >-
+      Enigu retpoŝtan adreson.
+    passwordTooShort: &error.passwordTooShort >-
+      La pasvorto devas havi almenaŭ 6 signojn.
+    passwordTooLong: &error.passwordTooLong >-
+      La pasvorto devas havi apenaŭ 50 signojn.
+    passwordRequired: &error.passwordRequired >-
+      Enigu pasvorton.
+    agreeRequired: >-
+      Por uzi tiun aplikaĵon, vi devas legi kaj konsenti pri la privateca politiko.
+issueUserResetTokenForm:
+  label:
+    name: *label.name
+    email: *label.email
+  error:
+    nameRequired: *error.nameRequired
+    emailInvalid: *error.emailInvalid
+    emailRequired: *error.emailRequired
+  button:
+    confirm: "Sendi"
+resetUserPasswordForm:
+  label:
+    password: "Nova pasvorto"
+  error:
+    tooShort: *error.passwordTooShort
+    tooLong: *error.passwordTooLong
+    required: *error.passwordRequired
+  button:
+    confirm: "Restarigi"
 resourceList:
   empty: "Neniuj bildoj estas alŝutitaj"
   button:
@@ -644,6 +726,8 @@ searchWordAdvancedDialog:
     text: "Ŝlosilvorto"
   absent:
     element: "Neniuj kondiĉoj"
+  discard:
+    equivalent: "<NOT SET>"
   button:
     add:
       element: "Aldoni kondiĉon"
@@ -672,6 +756,35 @@ shareMenu:
 suggestionCard:
   maybe: "Ĉu vi celas…"
   message: "{title} <mute>de</mute> {nameNode}"
+templateWordList:
+  empty: "Neniuj ŝablonoj estas kreitaj"
+  button:
+    edit: "Detalo · Redakti"
+    discard: "Forigi"
+  label:
+    equivalent: "Tradukaĵoj ×{count}"
+    information: "Enhavoj ×{count}"
+    phrase: "Idiomaĵoj ×{count}"
+    variation: "Variaĵaj formoj ×{count}"
+    relation: "Rilataj vortoj ×{count}"
+  dialog:
+    discard:
+      message: >-
+        Tiu ŝablono estos forigita konstante.
+        Vi ne povas restaŭri ĝin poste.
+        Ĉu vi vere certas?
+      confirm: "Forigi"
+termsAgreementBanner:
+  message:
+    before: >-
+      La nova <termsLink>uzkondiĉoj</termsLink> kaj <privacyLink>privateca politiko</privacyLink> ekvalidos ekde {dateString}.
+      Bonvolu kontroli ilian enhavon kaj, se vi konsentas, premu la butonon “Konsenti”.
+      Notu, ke se vi daŭre uzas tiun aplikaĵon je aŭ post {dateString}, oni konsideros, ke vi konsentis pri ili.
+      Se vi ne konsentas, bonvolu forigi vian konton kaj eksporti viajn datumojn antaŭ tiam.
+    after: >-
+      La nova <termsLink>uzkondiĉoj</termsLink> kaj <privacyLink>privateca politiko</privacyLink> validas ekde {dateString}.
+  button:
+    agree: "Konsenti"
 userHeader:
   tab:
     dictionary: "Vortaroj"
@@ -710,126 +823,13 @@ wordList:
         Vi ne povas restaŭri ĝin poste.
         Ĉu vi vere certas?
       confirm: "Forigi"
-templateWordList:
-  empty: "Neniuj ŝablonoj estas kreitaj"
-  button:
-    edit: "Detalo · Redakti"
-    discard: "Forigi"
-  label:
-    equivalent: "Tradukaĵoj ×{count}"
-    information: "Enhavoj ×{count}"
-    phrase: "Idiomaĵoj ×{count}"
-    variation: "Variaĵaj formoj ×{count}"
-    relation: "Rilataj vortoj ×{count}"
-  dialog:
-    discard:
-      message: >-
-        Tiu ŝablono estos forigita konstante.
-        Vi ne povas restaŭri ĝin poste.
-        Ĉu vi vere certas?
-      confirm: "Forigi"
 wordNameFrequencyChart:
   other: "Aliaj"
 wordPopover:
   button:
     edit: "Redakti"
-loginForm:
-  label:
-    name: "Salutnomo"
-    password: "Pasvorto"
-  button:
-    confirm: "Ensaluti"
-    register: "Krei konton"
-    resetPassword: "Restarigi pasvorton"
-  or: "aŭ"
-  error:
-    nameRequired: >-
-      Enigu vian salutnomon.
-    passwordRequired: >-
-      Enigu vian pasvorton.
-registerForm:
-  label:
-    name: &label.name "Salutnomo"
-    email: &label.email "Retpoŝta adreso"
-    password: "Pasvorto"
-    agree: "Konsenti pri la <termsLink>uzkondiĉoj</termsLink> kaj <privacyLink>privateca politiko</privacyLink>"
-  button:
-    confirm: "Krei konton"
-  error:
-    nameInvalid: >-
-      La salutnomo devas ampleksi alfanombraj signoj, substrekoj kaj streketoj.
-      Ĝi ankaŭ devas enhavi almenaŭ unu neciferan signon.
-    nameTooLong: >-
-      La salutnomo devas havi apenaŭ 30 signojn.
-    nameRequired: &error.nameRequired >-
-      Enigu salutnomon.
-    emailInvalid: &error.emailInvalid >-
-      Enigu validan retpoŝtan adreson.
-    emailRequired: &error.emailRequired >-
-      Enigu retpoŝtan adreson.
-    passwordTooShort: &error.passwordTooShort >-
-      La pasvorto devas havi almenaŭ 6 signojn.
-    passwordTooLong: &error.passwordTooLong >-
-      La pasvorto devas havi apenaŭ 50 signojn.
-    passwordRequired: &error.passwordRequired >-
-      Enigu pasvorton.
-    agreeRequired: >-
-      Por uzi tiun aplikaĵon, vi devas legi kaj konsenti pri la privateca politiko.
-termsAgreementBanner:
-  message:
-    before: >-
-      La nova <termsLink>uzkondiĉoj</termsLink> kaj <privacyLink>privateca politiko</privacyLink> ekvalidos ekde {dateString}.
-      Bonvolu kontroli ilian enhavon kaj, se vi konsentas, premu la butonon “Konsenti”.
-      Notu, ke se vi daŭre uzas tiun aplikaĵon je aŭ post {dateString}, oni konsideros, ke vi konsentis pri ili.
-      Se vi ne konsentas, bonvolu forigi vian konton kaj eksporti viajn datumojn antaŭ tiam.
-    after: >-
-      La nova <termsLink>uzkondiĉoj</termsLink> kaj <privacyLink>privateca politiko</privacyLink> validas ekde {dateString}.
-  button:
-    agree: "Konsenti"
-issueUserResetTokenForm:
-  label:
-    name: *label.name
-    email: *label.email
-  error:
-    nameRequired: *error.nameRequired
-    emailInvalid: *error.emailInvalid
-    emailRequired: *error.emailRequired
-  button:
-    confirm: "Sendi"
-resetUserPasswordForm:
-  label:
-    password: "Nova pasvorto"
-  error:
-    tooShort: *error.passwordTooShort
-    tooLong: *error.passwordTooLong
-    required: *error.passwordRequired
-  button:
-    confirm: "Restarigi"
 
 # form
-commonForm:
-  button:
-    change: "Ŝanĝi"
-addEditInvitationButton:
-  heading: "Doni redaktan permeson"
-  label:
-    user: "Doni permeson al"
-  button:
-    open: "Doni redaktan permeson"
-    confirm: "Konfirmi"
-  error:
-    required: >-
-      Elektu uzanton.
-addTransferInvitationButton:
-  heading: "Transdoni"
-  label:
-    user: "Transdoni al"
-  button:
-    open: "Transdoni"
-    confirm: "Konfirmi"
-  error:
-    required: >-
-      Elektu uzanton.
 addDictionaryButton:
   heading: "Krei novan vortaron"
   label:
@@ -840,6 +840,16 @@ addDictionaryButton:
   error:
     required: >-
       Enigu nomon.
+addEditInvitationButton:
+  heading: "Doni redaktan permeson"
+  label:
+    user: "Doni permeson al"
+  button:
+    open: "Doni redaktan permeson"
+    confirm: "Konfirmi"
+  error:
+    required: >-
+      Elektu uzanton.
 addResourceButton:
   heading: "Alŝuti bildon"
   label:
@@ -853,6 +863,16 @@ addResourceButton:
     tooLarge: >-
       La dosiero estas tro granda.
       Vi ne povas alŝuti dosierojn pli grandajn ol 1 MB.
+addTransferInvitationButton:
+  heading: "Transdoni"
+  label:
+    user: "Transdoni al"
+  button:
+    open: "Transdoni"
+    confirm: "Konfirmi"
+  error:
+    required: >-
+      Elektu uzanton.
 changeAppearanceForm:
   label: 
     font:
@@ -866,17 +886,6 @@ changeAppearanceForm:
       label: "Kolora skemo"
       light: "Luma"
       dark: "Malluma"
-changeDictionaryNameForm:
-  error:
-    required: >-
-      Enigu nomon.
-changeDictionaryParamNameForm:
-  error:
-    invalid: >-
-      La identigilo devas ampleksi alfanombraj signoj, substrekoj kaj streketoj.
-      Ĝi ankaŭ devas enhavi almenaŭ unu neciferan signon.
-    tooLong: >-
-      La identigilo devas havi apenaŭ 30 signojn.
 changeDictionaryFontForm:
   label:
     kind:
@@ -961,6 +970,17 @@ changeDictionaryMarkdownFeaturesForm:
       font: >-
         La teksto enkludita en <pre>'{'</pre> kaj <pre>'}'</pre> estos montrata en la propran tiparon.
         Bonvolu ankaŭ ebligi “Enhavoj” en la sekcio “Propran tiparon” supre.
+changeDictionaryNameForm:
+  error:
+    required: >-
+      Enigu nomon.
+changeDictionaryParamNameForm:
+  error:
+    invalid: >-
+      La identigilo devas ampleksi alfanombraj signoj, substrekoj kaj streketoj.
+      Ĝi ankaŭ devas enhavi almenaŭ unu neciferan signon.
+    tooLong: >-
+      La identigilo devas havi apenaŭ 30 signojn.
 changeDictionarySettingsForm:
   label:
     enableAdvancedWord:
@@ -1015,10 +1035,9 @@ changeDictionaryShowNumbersForm:
 changeDictionarySlimeTitlesForm:
   label:
     pronunciation: "Por elparoloj"
-changeDictionaryWordCardTitlesForm:
-  label:
-    phrase: "Por idiomaĵoj"
-    example: "Por ekzemplaj frazoj"
+changeDictionarySourceForm:
+  button:
+    try: "Provi"
 changeDictionaryVisibilityForm:
   label:
     public: "Publika"
@@ -1032,9 +1051,10 @@ changeDictionaryVisibilityForm:
     private: >-
       Nur uzantoj kun redakta permeso povos vidi tiun vortaron.
       Uzantoj sen permeso ne povos aliri ĝin eĉ se ili scias la retadreson.
-changeDictionarySourceForm:
-  button:
-    try: "Provi"
+changeDictionaryWordCardTitlesForm:
+  label:
+    phrase: "Por idiomaĵoj"
+    example: "Por ekzemplaj frazoj"
 changeMyEmailForm:
   error:
     invalid: >-
@@ -1058,6 +1078,9 @@ changeMyScreenNameForm:
   error:
     required: >-
       Enigu kromnomon.
+commonForm:
+  button:
+    change: "Ŝanĝi"
 discardDictionaryButton:
   button:
     submit: "Forigi"
@@ -1067,9 +1090,6 @@ discardDictionaryButton:
       Vi ne povas restaŭri ĝin poste.
       Ĉu vi vere certas?
     confirm: "Forigi"
-logoutButton:
-  button:
-    submit: "Elsaluti"
 discardMeButton:
   button:
     submit: "Forigi"
@@ -1079,6 +1099,30 @@ discardMeButton:
       Vi ne povas restaŭri ĝin poste.
       Ĉu vi vere certas?
     confirm: "Forigi"
+downloadDictionaryForm:
+  button:
+    download: "Elŝuti"
+    back: "Reiri al paĝo de vortaro"
+  message:
+    processing: >-
+      Kreadas dosiero.
+    success: >-
+      La dosiero estas kreita.
+      Vi povas elŝuti ĝin per la butono sube.
+    error: >-
+      Malsukcesis krei la dosieron.
+generateMyApiCredentialForm:
+  button:
+    generate: "Generi"
+    copy: "Kopii"
+  toast: 
+    copy: >-
+      Via API-ŝlosilo estas kopiita.
+  caution: >-
+    Bonvolu kopii tiun ŝlosilon nun kaj savi ĝin en sigura loko, ĉar vi ne povos vidi ĝin poste.
+logoutButton:
+  button:
+    submit: "Elsaluti"
 queueDownloadDictionaryButton:
   heading: "Eksporti"
   label:
@@ -1096,18 +1140,6 @@ queueDownloadDictionaryButton:
   button:
     open: "Eksporti"
     confirm: "Konfirmi"
-downloadDictionaryForm:
-  button:
-    download: "Elŝuti"
-    back: "Reiri al paĝo de vortaro"
-  message:
-    processing: >-
-      Kreadas dosiero.
-    success: >-
-      La dosiero estas kreita.
-      Vi povas elŝuti ĝin per la butono sube.
-    error: >-
-      Malsukcesis krei la dosieron.
 queueUploadDictionaryButton:
   heading: "Importi"
   label:
@@ -1132,36 +1164,6 @@ uploadDictionaryForm:
       Via dosiero estas importita.
     error: >-
       Malsukcesis importi vian dosieron.
-generateMyApiCredentialForm:
-  button:
-    generate: "Generi"
-    copy: "Kopii"
-  toast: 
-    copy: >-
-      Via API-ŝlosilo estas kopiita.
-  caution: >-
-    Bonvolu kopii tiun ŝlosilon nun kaj savi ĝin en sigura loko, ĉar vi ne povos vidi ĝin poste.
-apiCredentialList:
-  button:
-    copy: "Kopii"
-    discard: "Forigi"
-  dialog:
-    discard:
-      message: >-
-        Tiu API-ŝlosilo estos forigita.
-        Programoj uzantaj tiun API-ŝlosilon ne plu povos aliri vortarojn.
-        Ĉu vi certas?
-      confirm: "Forigi"
-  table:
-    createdDate: "Eldonita je"
-    lastUsedDate: "Laste uzita je"
-    neverUsed: "Neniam uzita"
-  caution: >-
-    Bonvolu kopii tiun ŝlosilon nun kaj savi ĝin en sigura loko, ĉar vi ne povos vidi ĝin poste.
-  empty: "Vi ankoraŭ ne eldonis iun ajn API-ŝlosilon"
-  toast:
-    copy: >-
-      Via API-ŝlosilo estas kopiita.
 
 # page
 contactPage:
@@ -1175,18 +1177,12 @@ contactPage:
     Vi ankaŭ povas uzi tion.
   disclaimer: |-
     Bonvolu noti, ke ni eble ne povos respondi ĉiujn demandojn rekte.
-exampleOfferListPage:
-  title: "Frazoj"
-  heading: "Frazoj"
 dictionaryArticlePart:
   button:
     addArticle: "Krei artikolon"
 dictionaryArticleSinglePart:
   button:
     back: "Reiri al listo"
-dictionaryProposalPart:
-  button:
-    addProposal: "Krei peton"
 dictionaryExamplePart:
   heading:
     offer: "Hodiaŭa frazo"
@@ -1202,23 +1198,18 @@ dictionaryInformationPart:
       La nombro estas registrita ĉiutage je ĉirkaŭ 14:30 (UTC).
     wordNameFrequency: >-
       La jena diagramo montras kiom ofta ĉiu signo aperas en la kapvortoj en tiu vortaro.
-dictionaryResourcePart:
-  explanation: >-
-    Vi povas uzi la alŝutitajn bildojn en la priskribo de la vortaro kaj la enhavoj de vortoj.
-    Kopiu la kodon sub la bildo kaj algluu ĝin en tekstujon.
 dictionaryMainPart:
   button:
     addWord: "Krei vorton"
     addWordFromTemplate: "Krei vorton de ŝablono"
     addProposal: "Peti"
-dictionarySettingPart:
-  tab:
-    general: "Ĝenerala"
-    display: "Vidigo"
-    editing: "Redaktado"
-    template: "Ŝablonoj"
-    authority: "Permesoj"
-    file: "Dosiero"
+dictionaryProposalPart:
+  button:
+    addProposal: "Krei peton"
+dictionaryResourcePart:
+  explanation: >-
+    Vi povas uzi la alŝutitajn bildojn en la priskribo de la vortaro kaj la enhavoj de vortoj.
+    Kopiu la kodon sub la bildo kaj algluu ĝin en tekstujon.
 dictionarySettingAuthorityPart:
   heading:
     editInvitation: "Permeso por redaktado"
@@ -1317,6 +1308,14 @@ dictionarySettingGeneralPart:
     discard: >-
       Forigi tiun vortaron ankaŭ forigos ĉiujn rilatajn datumojn, inkluzive de vortoj kaj ekzemplaj frazoj.
       Bonvolu esti certa, ĉar ne estas reiro.
+dictionarySettingPart:
+  tab:
+    general: "Ĝenerala"
+    display: "Vidigo"
+    editing: "Redaktado"
+    template: "Ŝablonoj"
+    authority: "Permesoj"
+    file: "Dosiero"
 dictionarySettingTemplatePart:
   heading:
     templateWords: "Ŝablonoj"
@@ -1352,6 +1351,9 @@ errorPage:
   button:
     back: "Reiri al ĉefpaĝo"
     refresh: "Reŝargi paĝon"
+exampleOfferListPage:
+  title: "Frazoj"
+  heading: "Frazoj"
 examplePage:
   add: "Krei novan frazon"
 loginPage:

--- a/client/message/eo.yml
+++ b/client/message/eo.yml
@@ -727,7 +727,7 @@ searchWordAdvancedDialog:
   absent:
     element: "Neniuj kondiĉoj"
   discard:
-    equivalent: "<NOT SET>"
+    equivalent: "Forigi"
   button:
     add:
       element: "Aldoni kondiĉon"

--- a/client/message/ja.yml
+++ b/client/message/ja.yml
@@ -727,7 +727,7 @@ searchWordAdvancedDialog:
   absent:
     element: "条件が設定されていません"
   discard:
-    equivalent: "<NOT SET>"
+    equivalent: "削除"
   button:
     add:
       element: "条件を追加"

--- a/client/message/ja.yml
+++ b/client/message/ja.yml
@@ -243,6 +243,13 @@ toast:
 commonAlert:
   confirm: "決定"
   cancel: "キャンセル"
+exampleModeSelect:
+  label:
+    sentence: "例文"
+    translation: "訳文"
+    both: "例文＋訳文"
+    tag: "タグ"
+    content: "全文"
 exampleOfferTag:
   catalog:
     zpdicDaily: "今日の例文"
@@ -257,13 +264,6 @@ exampleOfferTag:
     arithmetic: "算数例文"
     adposition: "格や接置詞のための例文集"
   number: "#{number, number}"
-exampleModeSelect:
-  label:
-    sentence: "例文"
-    translation: "訳文"
-    both: "例文＋訳文"
-    tag: "タグ"
-    content: "全文"
 exampleTypeSelect:
   label:
     prefix: "前方"
@@ -300,6 +300,28 @@ addProposalDialog:
   error:
     nameRequired: >-
       単語を入力してください。
+apiCredentialList:
+  button:
+    copy: "コピー"
+    discard: "削除"
+  dialog:
+    discard:
+      message: >-
+        この API キーを削除します。
+        この API キーを使用しているプログラムからは辞書にアクセスできなくなります。
+        本当によろしいですか?
+      confirm: "削除"
+  table:
+    createdDate: "発行日時"
+    lastUsedDate: "最終使用日時"
+    neverUsed: "未使用"
+  caution: >-
+    API キーを後から確認することはできません。
+    今の段階でコピーして保存しておいてください。
+  empty: "まだ API キーを発行していません"
+  toast:
+    copy: >-
+      API キーをコピーしました。
 articleList:
   empty: "記事は作成されていません"
   button:
@@ -315,17 +337,6 @@ articleList:
       confirm: "削除"
 changeLocaleForm:
   label: "言語"
-proposalList:
-  empty: "造語依頼はされていません"
-  button:
-    add: "造語"
-    discard: "削除"
-  dialog:
-    discard:
-      message: >-
-        この造語依頼を削除します。
-        本当によろしいですか?
-      confirm: "削除"
 contactForm:
   label:
     name: "名前"
@@ -342,16 +353,6 @@ contactForm:
       お問い合わせ内容を入力してください。
     agreeRequired: >-
       プライバシーポリシーを読んで同意してください。
-memberList:
-  empty: "編集権限のあるユーザーはいません"
-  button:
-    discard: "解除"
-  dialog:
-    discard:
-      message: >-
-        このユーザーの編集権限を解除します。
-        本当によろしいですか?
-      confirm: "解除"
 dictionaryHeader:
   tab:
     dictionary: "辞書"
@@ -595,6 +596,30 @@ invitationList:
   button:
     accept: "承認"
     reject: "拒否"
+loginForm:
+  label:
+    name: "ユーザー ID"
+    password: "パスワード"
+  button:
+    confirm: "ログイン"
+    register: "新規登録"
+    resetPassword: "パスワードリセット"
+  or: "or"
+  error:
+    nameRequired: >-
+      ユーザー ID を入力してください。
+    passwordRequired: >-
+      パスワードを入力してください。
+memberList:
+  empty: "編集権限のあるユーザーはいません"
+  button:
+    discard: "解除"
+  dialog:
+    discard:
+      message: >-
+        このユーザーの編集権限を解除します。
+        本当によろしいですか?
+      confirm: "解除"
 notificationList:
   tag:
     update: "アップデート"
@@ -611,6 +636,63 @@ orderModeSelect:
   custom: "独自順"
   updatedDate: "更新日時"
   createdDate: "作成日時"
+proposalList:
+  empty: "造語依頼はされていません"
+  button:
+    add: "造語"
+    discard: "削除"
+  dialog:
+    discard:
+      message: >-
+        この造語依頼を削除します。
+        本当によろしいですか?
+      confirm: "削除"
+registerForm:
+  label:
+    name: &label.name "ユーザー ID"
+    email: &label.email "メールアドレス"
+    password: "パスワード"
+    agree: "<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>に同意する"
+  button:
+    confirm: "新規登録"
+  error:
+    nameInvalid: >-
+      ユーザー ID は、半角英数字とアンダーバーとハイフンのみで構成され、数字以外の文字が 1 文字以上含まれている必要があります。
+    nameTooLong: >-
+      ユーザー ID は 30 文字以下である必要があります。
+    nameRequired: &error.nameRequired >-
+      ユーザー ID を入力してください。
+    emailInvalid: &error.emailInvalid >-
+      正しい形式のメールアドレスを入力してください。
+    emailRequired: &error.emailRequired >-
+      メールアドレスを入力してください。
+    passwordTooShort: &error.passwordTooShort >-
+      パスワードは 6 文字以上である必要があります。
+    passwordTooLong: &error.passwordTooLong >-
+      パスワードは 50 文字以下である必要があります。
+    passwordRequired: &error.passwordRequired >-
+      パスワードを入力してください。
+    agreeRequired: >-
+      このアプリケーションを利用していただくには、プライバシーポリシーをお読みいただき同意していただく必要があります。
+issueUserResetTokenForm:
+  label:
+    name: *label.name
+    email: *label.email
+  error:
+    nameRequired: *error.nameRequired
+    emailInvalid: *error.emailInvalid
+    emailRequired: *error.emailRequired
+  button:
+    confirm: "送信"
+resetUserPasswordForm:
+  label:
+    password: "新しいパスワード"
+  error:
+    tooShort: *error.passwordTooShort
+    tooLong: *error.passwordTooLong
+    required: *error.passwordRequired
+  button:
+    confirm: "リセット"
 resourceList:
   empty: "画像は登録されていません"
   button:
@@ -644,6 +726,8 @@ searchWordAdvancedDialog:
     text: "検索内容"
   absent:
     element: "条件が設定されていません"
+  discard:
+    equivalent: "<NOT SET>"
   button:
     add:
       element: "条件を追加"
@@ -672,6 +756,35 @@ shareMenu:
 suggestionCard:
   maybe: "もしかして…"
   message: "{nameNode} <mute>の</mute> {title}"
+templateWordList:
+  empty: "テンプレートは作成されていません"
+  button:
+    edit: "詳細 · 編集"
+    discard: "削除"
+  label:
+    equivalent: "訳語 ×{count}"
+    information: "内容 ×{count}"
+    phrase: "成句 ×{count}"
+    variation: "変化形 ×{count}"
+    relation: "関連語 ×{count}"
+  dialog:
+    discard:
+      message: >-
+        このテンプレートを削除します。
+        削除した後にデータを戻すことはできません。
+        本当によろしいですか?
+      confirm: "削除"
+termsAgreementBanner:
+  message:
+    before: >-
+      新しい<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>が {dateString} から適用される予定です。
+      内容をご確認の上、同意いただける場合は「同意する」ボタンを押してください。
+      なお、{dateString} 以降も利用を続けられた場合は、これらに同意したものと見なします。
+      同意いただけない場合は、それまでに退会およびデータのエクスポートをお願いします。
+    after: >-
+      新しい<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>が {dateString} から適用されています。
+  button:
+    agree: "同意する"
 userHeader:
   tab:
     dictionary: "辞書"
@@ -710,125 +823,13 @@ wordList:
         削除した後にデータを戻すことはできません。
         本当によろしいですか?
       confirm: "削除"
-templateWordList:
-  empty: "テンプレートは作成されていません"
-  button:
-    edit: "詳細 · 編集"
-    discard: "削除"
-  label:
-    equivalent: "訳語 ×{count}"
-    information: "内容 ×{count}"
-    phrase: "成句 ×{count}"
-    variation: "変化形 ×{count}"
-    relation: "関連語 ×{count}"
-  dialog:
-    discard:
-      message: >-
-        このテンプレートを削除します。
-        削除した後にデータを戻すことはできません。
-        本当によろしいですか?
-      confirm: "削除"
 wordNameFrequencyChart:
   other: "その他"
 wordPopover:
   button:
     edit: "編集"
-loginForm:
-  label:
-    name: "ユーザー ID"
-    password: "パスワード"
-  button:
-    confirm: "ログイン"
-    register: "新規登録"
-    resetPassword: "パスワードリセット"
-  or: "or"
-  error:
-    nameRequired: >-
-      ユーザー ID を入力してください。
-    passwordRequired: >-
-      パスワードを入力してください。
-registerForm:
-  label:
-    name: &label.name "ユーザー ID"
-    email: &label.email "メールアドレス"
-    password: "パスワード"
-    agree: "<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>に同意する"
-  button:
-    confirm: "新規登録"
-  error:
-    nameInvalid: >-
-      ユーザー ID は、半角英数字とアンダーバーとハイフンのみで構成され、数字以外の文字が 1 文字以上含まれている必要があります。
-    nameTooLong: >-
-      ユーザー ID は 30 文字以下である必要があります。
-    nameRequired: &error.nameRequired >-
-      ユーザー ID を入力してください。
-    emailInvalid: &error.emailInvalid >-
-      正しい形式のメールアドレスを入力してください。
-    emailRequired: &error.emailRequired >-
-      メールアドレスを入力してください。
-    passwordTooShort: &error.passwordTooShort >-
-      パスワードは 6 文字以上である必要があります。
-    passwordTooLong: &error.passwordTooLong >-
-      パスワードは 50 文字以下である必要があります。
-    passwordRequired: &error.passwordRequired >-
-      パスワードを入力してください。
-    agreeRequired: >-
-      このアプリケーションを利用していただくには、プライバシーポリシーをお読みいただき同意していただく必要があります。
-termsAgreementBanner:
-  message:
-    before: >-
-      新しい<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>が {dateString} から適用される予定です。
-      内容をご確認の上、同意いただける場合は「同意する」ボタンを押してください。
-      なお、{dateString} 以降も利用を続けられた場合は、これらに同意したものと見なします。
-      同意いただけない場合は、それまでに退会およびデータのエクスポートをお願いします。
-    after: >-
-      新しい<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>が {dateString} から適用されています。
-  button:
-    agree: "同意する"
-issueUserResetTokenForm:
-  label:
-    name: *label.name
-    email: *label.email
-  error:
-    nameRequired: *error.nameRequired
-    emailInvalid: *error.emailInvalid
-    emailRequired: *error.emailRequired
-  button:
-    confirm: "送信"
-resetUserPasswordForm:
-  label:
-    password: "新しいパスワード"
-  error:
-    tooShort: *error.passwordTooShort
-    tooLong: *error.passwordTooLong
-    required: *error.passwordRequired
-  button:
-    confirm: "リセット"
 
 # form
-commonForm:
-  button:
-    change: "変更"
-addEditInvitationButton:
-  heading: "編集権限を付与"
-  label:
-    user: "権限を付与するユーザー"
-  button:
-    open: "編集権限をユーザーに付与"
-    confirm: "決定"
-  error:
-    required: >-
-      ユーザーを選択してください。
-addTransferInvitationButton:
-  heading: "譲渡"
-  label:
-    user: "譲渡先のユーザー"
-  button:
-    open: "譲渡"
-    confirm: "決定"
-  error:
-    required: >-
-      ユーザーを選択してください。
 addDictionaryButton:
   heading: "新しい辞書を作成"
   label:
@@ -839,6 +840,16 @@ addDictionaryButton:
   error:
     required: >-
       名前を選択してください。
+addEditInvitationButton:
+  heading: "編集権限を付与"
+  label:
+    user: "権限を付与するユーザー"
+  button:
+    open: "編集権限をユーザーに付与"
+    confirm: "決定"
+  error:
+    required: >-
+      ユーザーを選択してください。
 addResourceButton:
   heading: "画像をアップロード"
   label:
@@ -852,6 +863,16 @@ addResourceButton:
     tooLarge: >-
       ファイルのサイズが大きすぎます。
       1 MB より大きなファイルはアップロードすることができません。
+addTransferInvitationButton:
+  heading: "譲渡"
+  label:
+    user: "譲渡先のユーザー"
+  button:
+    open: "譲渡"
+    confirm: "決定"
+  error:
+    required: >-
+      ユーザーを選択してください。
 changeAppearanceForm:
   label: 
     font:
@@ -865,16 +886,6 @@ changeAppearanceForm:
       label: "配色テーマ"
       light: "ライト"
       dark: "ダーク"
-changeDictionaryNameForm:
-  error:
-    required: >-
-      名前を入力してください。
-changeDictionaryParamNameForm:
-  error:
-    invalid: >-
-      識別子は、半角英数字とアンダーバーとハイフンのみで構成され、数字以外の文字が 1 文字以上含まれている必要があります。
-    tooLong: >-
-      識別子は 30 文字以下である必要があります。
 changeDictionaryFontForm:
   label:
     kind:
@@ -959,6 +970,16 @@ changeDictionaryMarkdownFeaturesForm:
       font: >-
         <pre>'{'</pre> と <pre>'}'</pre> で囲まれた箇所が専用フォントで表示されるようになります。
         上の「専用フォント」項目で「本文」にチェックを入れてください。
+changeDictionaryNameForm:
+  error:
+    required: >-
+      名前を入力してください。
+changeDictionaryParamNameForm:
+  error:
+    invalid: >-
+      識別子は、半角英数字とアンダーバーとハイフンのみで構成され、数字以外の文字が 1 文字以上含まれている必要があります。
+    tooLong: >-
+      識別子は 30 文字以下である必要があります。
 changeDictionarySettingsForm:
   label:
     enableAdvancedWord:
@@ -1013,10 +1034,9 @@ changeDictionaryShowNumbersForm:
 changeDictionarySlimeTitlesForm:
   label:
     pronunciation: "発音"
-changeDictionaryWordCardTitlesForm:
-  label:
-    phrase: "成句"
-    example: "例文"
+changeDictionarySourceForm:
+  button:
+    try: "試す"
 changeDictionaryVisibilityForm:
   label:
     public: "全体公開"
@@ -1030,9 +1050,10 @@ changeDictionaryVisibilityForm:
     private: >-
       編集権限がある人のみ閲覧できます。
       権限がない人は URL から直接アクセスしても閲覧できません。
-changeDictionarySourceForm:
-  button:
-    try: "試す"
+changeDictionaryWordCardTitlesForm:
+  label:
+    phrase: "成句"
+    example: "例文"
 changeMyEmailForm:
   error:
     invalid: >-
@@ -1056,6 +1077,9 @@ changeMyScreenNameForm:
   error:
     required: >-
       ニックネームを入力してください。
+commonForm:
+  button:
+    change: "変更"
 discardDictionaryButton:
   button:
     submit: "削除"
@@ -1065,9 +1089,6 @@ discardDictionaryButton:
       削除した後にデータを戻すことはできません。
       本当によろしいですか?
     confirm: "削除"
-logoutButton:
-  button:
-    submit: "ログアウト"
 discardMeButton:
   button:
     submit: "削除"
@@ -1077,6 +1098,32 @@ discardMeButton:
       削除した後にデータを戻すことはできません。
       本当によろしいですか?
     confirm: "削除"
+downloadDictionaryForm:
+  button:
+    download: "ダウンロード"
+    back: "辞書ページに戻る"
+  message:
+    processing: >-
+      ファイルを作成中です。
+      このページを開いたまましばらくお待ちください。
+    success: >-
+      ファイルの作成が完了しました。
+      以下のボタンからダウンロードできます。
+    error: >-
+      ファイルの作成に失敗しました。
+generateMyApiCredentialForm:
+  button:
+    generate: "新規生成"
+    copy: "コピー"
+  toast: 
+    copy: >-
+      API キーをコピーしました。
+  caution: >-
+    API キーを後から確認することはできません。
+    今の段階でコピーして保存しておいてください。
+logoutButton:
+  button:
+    submit: "ログアウト"
 queueDownloadDictionaryButton:
   heading: "エクスポート"
   label:
@@ -1094,19 +1141,6 @@ queueDownloadDictionaryButton:
   button:
     open: "エクスポート"
     confirm: "決定"
-downloadDictionaryForm:
-  button:
-    download: "ダウンロード"
-    back: "辞書ページに戻る"
-  message:
-    processing: >-
-      ファイルを作成中です。
-      このページを開いたまましばらくお待ちください。
-    success: >-
-      ファイルの作成が完了しました。
-      以下のボタンからダウンロードできます。
-    error: >-
-      ファイルの作成に失敗しました。
 queueUploadDictionaryButton:
   heading: "インポート"
   label:
@@ -1131,38 +1165,6 @@ uploadDictionaryForm:
       インポートが完了しました。
     error: >-
       インポートに失敗しました。
-generateMyApiCredentialForm:
-  button:
-    generate: "新規生成"
-    copy: "コピー"
-  toast: 
-    copy: >-
-      API キーをコピーしました。
-  caution: >-
-    API キーを後から確認することはできません。
-    今の段階でコピーして保存しておいてください。
-apiCredentialList:
-  button:
-    copy: "コピー"
-    discard: "削除"
-  dialog:
-    discard:
-      message: >-
-        この API キーを削除します。
-        この API キーを使用しているプログラムからは辞書にアクセスできなくなります。
-        本当によろしいですか?
-      confirm: "削除"
-  table:
-    createdDate: "発行日時"
-    lastUsedDate: "最終使用日時"
-    neverUsed: "未使用"
-  caution: >-
-    API キーを後から確認することはできません。
-    今の段階でコピーして保存しておいてください。
-  empty: "まだ API キーを発行していません"
-  toast:
-    copy: >-
-      API キーをコピーしました。
 
 # page
 contactPage:
@@ -1177,18 +1179,12 @@ contactPage:
   disclaimer: |-
     なお、全てのお問い合わせに直接お答えできるとは限りません。
     あらかじめご了承ください。
-exampleOfferListPage:
-  title: "例文集"
-  heading: "例文集"
 dictionaryArticlePart:
   button:
     addArticle: "記事を作成"
 dictionaryArticleSinglePart:
   button:
     back: "一覧に戻る"
-dictionaryProposalPart:
-  button:
-    addProposal: "造語依頼"
 dictionaryExamplePart:
   heading:
     offer: "今日の例文"
@@ -1209,18 +1205,13 @@ dictionaryMainPart:
     addWord: "単語を作成"
     addWordFromTemplate: "テンプレートから単語を作成"
     addProposal: "造語依頼"
+dictionaryProposalPart:
+  button:
+    addProposal: "造語依頼"
 dictionaryResourcePart:
   explanation: >-
     アップロードした画像は、辞書の説明欄や単語の内容欄で使用することができます。
     画像の下に表示されているコードを貼り付けてください。
-dictionarySettingPart:
-  tab:
-    general: "一般"
-    display: "表示"
-    editing: "編集"
-    template: "テンプレート"
-    authority: "権限"
-    file: "ファイル"
 dictionarySettingAuthorityPart:
   heading:
     editInvitation: "編集権限"
@@ -1320,6 +1311,14 @@ dictionarySettingGeneralPart:
     discard: >-
       この辞書を削除すると、単語や例文などの関連するデータも全て削除されます。
       後からデータを復元することはできないので、慎重に行ってください。
+dictionarySettingPart:
+  tab:
+    general: "一般"
+    display: "表示"
+    editing: "編集"
+    template: "テンプレート"
+    authority: "権限"
+    file: "ファイル"
 dictionarySettingTemplatePart:
   heading:
     templateWords: "テンプレート"
@@ -1355,6 +1354,9 @@ errorPage:
   button:
     back: "トップページへ"
     refresh: "ページを再読み込み"
+exampleOfferListPage:
+  title: "例文集"
+  heading: "例文集"
 examplePage:
   add: "新しい単語を作成"
 loginPage:


### PR DESCRIPTION
client アプリの国際化メッセージファイル (`client/message/ja.yml`, `en.yml`, `eo.yml`) を `maintain-messages` skill で整備しました。

## 未設定メッセージの追加
コードが参照しているのにメッセージファイルに未設定だったキーを追加しました。

### `<NOT SET>` で追加 (翻訳元が `ja.yml` にもなかったもの)
- `searchWordAdvancedDialog.discard.equivalent` (ja / en / eo の 3 言語すべて)

### 翻訳して追加 (`ja.yml` に翻訳元があったもの)
- なし

> ⚠️ `<NOT SET>` のままのキーは実際のメッセージではありません。別途、実際のメッセージへ置き換える必要があります。

## 並び替え
各ファイルを以下の体裁に整えました (メッセージ本文は変更していません)。

- セクションを `toast` → `atom` → `compound` → `form` → `page` → `other` の順に整列。
- 各セクション内のルートキーをアルファベット順に整列 (`toast` は `success` → `error` の固定順、YAML アンカー依存は尊重)。
- 副次的な修正: `en.yml` にあった重複セクションコメントの解消、`apiCredentialList` の所属セクション (`form` → `compound`) の修正。

## 補足
- テンプレートリテラルで動的に組み立てられるキー (39 件) は自動解決できないため対象外です。対応するメッセージが揃っているかは別途手動確認が必要です。