### PR TITLE
メッセージファイルの YAML 相互参照を展開

### DIFF
--- a/client/message/en.yml
+++ b/client/message/en.yml
@@ -648,8 +648,8 @@ proposalList:
       confirm: "Delete"
 registerForm:
   label:
-    name: &label.name "Username"
-    email: &label.email "Email address"
+    name: "Username"
+    email: "Email address"
     password: "Password"
     agree: "Agree to the <termsLink>terms of service</termsLink> and <privacyLink>privacy policy</privacyLink>"
   button:
@@ -660,37 +660,43 @@ registerForm:
       It must also contain at least one non-digit.
     nameTooLong: >-
       The username must contain no more than 30 characters.
-    nameRequired: &error.nameRequired >-
+    nameRequired: >-
       Enter a username.
-    emailInvalid: &error.emailInvalid >-
+    emailInvalid: >-
       Enter a valid email address.
-    emailRequired: &error.emailRequired >-
+    emailRequired: >-
       Enter an email address.
-    passwordTooShort: &error.passwordTooShort >-
+    passwordTooShort: >-
       The password must contain at least 6 characters.
-    passwordTooLong: &error.passwordTooLong >-
+    passwordTooLong: >-
       The password must contain no more than 50 characters.
-    passwordRequired: &error.passwordRequired >-
+    passwordRequired: >-
       Enter a password.
     agreeRequired: >-
       In order to use this application, you must read and agree to the privacy policy.
 issueUserResetTokenForm:
   label:
-    name: *label.name
-    email: *label.email
+    name: "Username"
+    email: "Email address"
   error:
-    nameRequired: *error.nameRequired
-    emailInvalid: *error.emailInvalid
-    emailRequired: *error.emailRequired
+    nameRequired: >-
+      Enter a username.
+    emailInvalid: >-
+      Enter a valid email address.
+    emailRequired: >-
+      Enter an email address.
   button:
     confirm: "Send"
 resetUserPasswordForm:
   label:
     password: "New password"
   error:
-    tooShort: *error.passwordTooShort
-    tooLong: *error.passwordTooLong
-    required: *error.passwordRequired
+    tooShort: >-
+      The password must contain at least 6 characters.
+    tooLong: >-
+      The password must contain no more than 50 characters.
+    required: >-
+      Enter a password.
   button:
     confirm: "Reset"
 resourceList:

--- a/client/message/eo.yml
+++ b/client/message/eo.yml
@@ -648,8 +648,8 @@ proposalList:
       confirm: "Forigi"
 registerForm:
   label:
-    name: &label.name "Salutnomo"
-    email: &label.email "Retpoŝta adreso"
+    name: "Salutnomo"
+    email: "Retpoŝta adreso"
     password: "Pasvorto"
     agree: "Konsenti pri la <termsLink>uzkondiĉoj</termsLink> kaj <privacyLink>privateca politiko</privacyLink>"
   button:
@@ -660,37 +660,43 @@ registerForm:
       Ĝi ankaŭ devas enhavi almenaŭ unu neciferan signon.
     nameTooLong: >-
       La salutnomo devas havi apenaŭ 30 signojn.
-    nameRequired: &error.nameRequired >-
+    nameRequired: >-
       Enigu salutnomon.
-    emailInvalid: &error.emailInvalid >-
+    emailInvalid: >-
       Enigu validan retpoŝtan adreson.
-    emailRequired: &error.emailRequired >-
+    emailRequired: >-
       Enigu retpoŝtan adreson.
-    passwordTooShort: &error.passwordTooShort >-
+    passwordTooShort: >-
       La pasvorto devas havi almenaŭ 6 signojn.
-    passwordTooLong: &error.passwordTooLong >-
+    passwordTooLong: >-
       La pasvorto devas havi apenaŭ 50 signojn.
-    passwordRequired: &error.passwordRequired >-
+    passwordRequired: >-
       Enigu pasvorton.
     agreeRequired: >-
       Por uzi tiun aplikaĵon, vi devas legi kaj konsenti pri la privateca politiko.
 issueUserResetTokenForm:
   label:
-    name: *label.name
-    email: *label.email
+    name: "Salutnomo"
+    email: "Retpoŝta adreso"
   error:
-    nameRequired: *error.nameRequired
-    emailInvalid: *error.emailInvalid
-    emailRequired: *error.emailRequired
+    nameRequired: >-
+      Enigu salutnomon.
+    emailInvalid: >-
+      Enigu validan retpoŝtan adreson.
+    emailRequired: >-
+      Enigu retpoŝtan adreson.
   button:
     confirm: "Sendi"
 resetUserPasswordForm:
   label:
     password: "Nova pasvorto"
   error:
-    tooShort: *error.passwordTooShort
-    tooLong: *error.passwordTooLong
-    required: *error.passwordRequired
+    tooShort: >-
+      La pasvorto devas havi almenaŭ 6 signojn.
+    tooLong: >-
+      La pasvorto devas havi apenaŭ 50 signojn.
+    required: >-
+      Enigu pasvorton.
   button:
     confirm: "Restarigi"
 resourceList:

--- a/client/message/ja.yml
+++ b/client/message/ja.yml
@@ -649,8 +649,8 @@ proposalList:
       confirm: "削除"
 registerForm:
   label:
-    name: &label.name "ユーザー ID"
-    email: &label.email "メールアドレス"
+    name: "ユーザー ID"
+    email: "メールアドレス"
     password: "パスワード"
     agree: "<termsLink>利用規約</termsLink>と<privacyLink>プライバシーポリシー</privacyLink>に同意する"
   button:
@@ -660,37 +660,43 @@ registerForm:
       ユーザー ID は、半角英数字とアンダーバーとハイフンのみで構成され、数字以外の文字が 1 文字以上含まれている必要があります。
     nameTooLong: >-
       ユーザー ID は 30 文字以下である必要があります。
-    nameRequired: &error.nameRequired >-
+    nameRequired: >-
       ユーザー ID を入力してください。
-    emailInvalid: &error.emailInvalid >-
+    emailInvalid: >-
       正しい形式のメールアドレスを入力してください。
-    emailRequired: &error.emailRequired >-
+    emailRequired: >-
       メールアドレスを入力してください。
-    passwordTooShort: &error.passwordTooShort >-
+    passwordTooShort: >-
       パスワードは 6 文字以上である必要があります。
-    passwordTooLong: &error.passwordTooLong >-
+    passwordTooLong: >-
       パスワードは 50 文字以下である必要があります。
-    passwordRequired: &error.passwordRequired >-
+    passwordRequired: >-
       パスワードを入力してください。
     agreeRequired: >-
       このアプリケーションを利用していただくには、プライバシーポリシーをお読みいただき同意していただく必要があります。
 issueUserResetTokenForm:
   label:
-    name: *label.name
-    email: *label.email
+    name: "ユーザー ID"
+    email: "メールアドレス"
   error:
-    nameRequired: *error.nameRequired
-    emailInvalid: *error.emailInvalid
-    emailRequired: *error.emailRequired
+    nameRequired: >-
+      ユーザー ID を入力してください。
+    emailInvalid: >-
+      正しい形式のメールアドレスを入力してください。
+    emailRequired: >-
+      メールアドレスを入力してください。
   button:
     confirm: "送信"
 resetUserPasswordForm:
   label:
     password: "新しいパスワード"
   error:
-    tooShort: *error.passwordTooShort
-    tooLong: *error.passwordTooLong
-    required: *error.passwordRequired
+    tooShort: >-
+      パスワードは 6 文字以上である必要があります。
+    tooLong: >-
+      パスワードは 50 文字以下である必要があります。
+    required: >-
+      パスワードを入力してください。
   button:
     confirm: "リセット"
 resourceList:


### PR DESCRIPTION
## Summary
- `client/message/ja.yml`, `en.yml`, `eo.yml` の `registerForm` セクションで定義していたラベル・エラーメッセージを、YAML のアンカー (`&`) ・エイリアス (`*`) によって `issueUserResetTokenForm`, `resetUserPasswordForm` から参照していた箇所を展開し、各キーに値を直接記述する形に変更
- 3 言語ファイルとも同じ 8 箇所 (ラベル 2 件・エラーメッセージ 6 件) が対象で、参照関係を解消しても表示される文言に変化はない

## Test plan
- [x] 変更後の 3 ファイルが YAML として正しくパースできることを確認 (`python3 -c "import yaml; ..."`)
- [x] アンカー・エイリアス構文 (`&`, `*`) が 3 ファイルから完全に除去されたことを `grep` で確認
- [x] 展開後の値が元の参照先と一致することを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwmFgNm88eJxqTfLkPv8H8)_