### PR TITLE
ユーザーページの辞書一覧から削除済み辞書を除外

### DIFF
--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -116,7 +116,7 @@ export class DictionarySchema extends DiscardableSchema {
    * `me` に `null` を指定した場合は、ユーザーに関わらず全員が見ることのできる辞書のみを返します (公開範囲が限定公開以下のものは除外される)。*/
   public static async fetchByUser(user: User, me: Pick<User, "id"> | null): Promise<Array<Dictionary>> {
     const meInvolvedDictionaryIds = (me !== null) ? await MemberModel.fetchDictionaryIdsByUser(me, "edit") : [];
-    const dictionaries = await DictionaryModel.find().where("user", user).or([
+    const dictionaries = await DictionaryModel.findExist().where("user", user).or([
       {"visibility": "public"},
       {"user": me},
       DictionaryModel.find().in("_id", meInvolvedDictionaryIds).getFilter()


### PR DESCRIPTION
fetchByUser が find() を使っており、論理削除 (removedDate
セット済み) された辞書も一覧に含まれてしまっていた。他の辞書
取得系メソッドと同様に findExist() を用いて削除済みを除外する。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MSr4dwDw1wKs2GeKxBERQM