### PR TITLE
汎用 Banner コンポーネントを compound に追加し 2 つのバナーを共通化

### DIFF
--- a/client/component/compound/banner/banner-body.scss
+++ b/client/component/compound/banner/banner-body.scss
@@ -1,0 +1,10 @@
+@charset "utf-8";
+
+@use "zographia/source/component/function.scss" as *;
+
+
+.root {
+  row-gap: 3zu;
+  display: flex;
+  flex-direction: column;
+}

--- a/client/component/compound/banner/banner-body.tsx
+++ b/client/component/compound/banner/banner-body.tsx
@@ -6,7 +6,7 @@ import {create} from "/client/component/create";
 
 
 export const BannerBody = create(
-  require("./banner.scss"), "BannerBody",
+  require("./banner-body.scss"), "BannerBody",
   function ({
     children,
     ...rest
@@ -16,7 +16,7 @@ export const BannerBody = create(
   } & AdditionalProps): ReactElement {
 
     return (
-      <div styleName="content" {...rest}>
+      <div styleName="root" {...rest}>
         {children}
       </div>
     );

--- a/client/component/compound/banner/banner-body.tsx
+++ b/client/component/compound/banner/banner-body.tsx
@@ -1,0 +1,25 @@
+//
+
+import {ReactElement, ReactNode} from "react";
+import {AdditionalProps} from "zographia";
+import {create} from "/client/component/create";
+
+
+export const BannerBody = create(
+  require("./banner.scss"), "BannerBody",
+  function ({
+    children,
+    ...rest
+  }: {
+    children?: ReactNode,
+    className?: string
+  } & AdditionalProps): ReactElement {
+
+    return (
+      <div styleName="content" {...rest}>
+        {children}
+      </div>
+    );
+
+  }
+);

--- a/client/component/compound/banner/banner-icon-container.scss
+++ b/client/component/compound/banner/banner-icon-container.scss
@@ -1,0 +1,9 @@
+@charset "utf-8";
+
+@use "zographia/source/component/function.scss" as *;
+
+
+.root {
+  font-size: 10zu;
+  color: var(--icon-color);
+}

--- a/client/component/compound/banner/banner-icon-container.tsx
+++ b/client/component/compound/banner/banner-icon-container.tsx
@@ -6,7 +6,7 @@ import {create} from "/client/component/create";
 
 
 export const BannerIconContainer = create(
-  require("./banner.scss"), "BannerIconContainer",
+  require("./banner-icon-container.scss"), "BannerIconContainer",
   function ({
     children,
     ...rest
@@ -16,7 +16,7 @@ export const BannerIconContainer = create(
   } & AdditionalProps): ReactElement {
 
     return (
-      <div styleName="icon" {...rest}>
+      <div styleName="root" {...rest}>
         {children}
       </div>
     );

--- a/client/component/compound/banner/banner-icon-container.tsx
+++ b/client/component/compound/banner/banner-icon-container.tsx
@@ -1,0 +1,24 @@
+//
+
+import {IconDefinition} from "@fortawesome/sharp-regular-svg-icons";
+import {ReactElement} from "react";
+import {AdditionalProps, GeneralIcon} from "zographia";
+import {create} from "/client/component/create";
+
+
+export const BannerIconContainer = create(
+  require("./banner.scss"), "BannerIconContainer",
+  function ({
+    icon,
+    ...rest
+  }: {
+    icon: IconDefinition,
+    className?: string
+  } & AdditionalProps): ReactElement {
+
+    return (
+      <GeneralIcon styleName="icon" icon={icon} {...rest}/>
+    );
+
+  }
+);

--- a/client/component/compound/banner/banner-icon-container.tsx
+++ b/client/component/compound/banner/banner-icon-container.tsx
@@ -1,23 +1,24 @@
 //
 
-import {IconDefinition} from "@fortawesome/sharp-regular-svg-icons";
-import {ReactElement} from "react";
-import {AdditionalProps, GeneralIcon} from "zographia";
+import {ReactElement, ReactNode} from "react";
+import {AdditionalProps} from "zographia";
 import {create} from "/client/component/create";
 
 
 export const BannerIconContainer = create(
   require("./banner.scss"), "BannerIconContainer",
   function ({
-    icon,
+    children,
     ...rest
   }: {
-    icon: IconDefinition,
+    children?: ReactNode,
     className?: string
   } & AdditionalProps): ReactElement {
 
     return (
-      <GeneralIcon styleName="icon" icon={icon} {...rest}/>
+      <div styleName="icon" {...rest}>
+        {children}
+      </div>
     );
 
   }

--- a/client/component/compound/banner/banner.scss
+++ b/client/component/compound/banner/banner.scss
@@ -1,0 +1,36 @@
+@charset "utf-8";
+
+@use "zographia/source/component/function.scss" as *;
+
+
+.root {
+  @include theme("light") {
+    --background-color: #{leveled-color("red", 0)};
+    --border-color: #{leveled-color("red", 3)};
+    --icon-color: #{leveled-color("red", 5)};
+  }
+}
+
+.root {
+  padding-block: 4zu;
+  background-color: var(--background-color);
+  border-block-end: solid 1zx var(--border-color);
+}
+
+.container {
+  column-gap: 4zu;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: center;
+}
+
+.content {
+  row-gap: 3zu;
+  display: flex;
+  flex-direction: column;
+}
+
+.icon {
+  font-size: 10zu;
+  color: var(--icon-color);
+}

--- a/client/component/compound/banner/banner.scss
+++ b/client/component/compound/banner/banner.scss
@@ -23,14 +23,3 @@
   grid-template-columns: max-content 1fr;
   align-items: center;
 }
-
-.content {
-  row-gap: 3zu;
-  display: flex;
-  flex-direction: column;
-}
-
-.icon {
-  font-size: 10zu;
-  color: var(--icon-color);
-}

--- a/client/component/compound/banner/banner.tsx
+++ b/client/component/compound/banner/banner.tsx
@@ -1,0 +1,28 @@
+//
+
+import {ReactElement, ReactNode} from "react";
+import {AdditionalProps} from "zographia";
+import {MainContainer} from "/client/component/compound/page";
+import {create} from "/client/component/create";
+
+
+export const Banner = create(
+  require("./banner.scss"), "Banner",
+  function ({
+    children,
+    ...rest
+  }: {
+    children?: ReactNode,
+    className?: string
+  } & AdditionalProps): ReactElement {
+
+    return (
+      <div styleName="root" {...rest}>
+        <MainContainer styleName="container" width="normal">
+          {children}
+        </MainContainer>
+      </div>
+    );
+
+  }
+);

--- a/client/component/compound/banner/index.ts
+++ b/client/component/compound/banner/index.ts
@@ -1,0 +1,5 @@
+//
+
+export * from "./banner";
+export * from "./banner-body";
+export * from "./banner-icon-container";

--- a/client/component/compound/header/activate-me-banner.scss
+++ b/client/component/compound/header/activate-me-banner.scss
@@ -3,38 +3,6 @@
 @use "zographia/source/component/function.scss" as *;
 
 
-.root {
-  @include theme("light") {
-    --background-color: #{leveled-color("red", 0)};
-    --border-color: #{leveled-color("red", 3)};
-    --icon-color: #{leveled-color("red", 5)};
-  }
-}
-
-.root {
-  padding-block: 4zu;
-  background-color: var(--background-color);
-  border-block-end: solid 1zx var(--border-color);
-}
-
-.container {
-  column-gap: 4zu;
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  align-items: center;
-}
-
-.content {
-  row-gap: 3zu;
-  display: flex;
-  flex-direction: column;
-}
-
-.icon {
-  font-size: 10zu;
-  color: var(--icon-color);
-}
-
 .button {
   align-self: flex-start;
 }

--- a/client/component/compound/header/activate-me-banner.tsx
+++ b/client/component/compound/header/activate-me-banner.tsx
@@ -25,7 +25,7 @@ export const ActivateMeBanner = create(
 
     return (me !== null && !me.activated) ? (
       <Banner {...rest}>
-        <BannerIconContainer icon={faExclamationCircle}/>
+        <BannerIconContainer><GeneralIcon icon={faExclamationCircle}/></BannerIconContainer>
         <BannerBody>
           <MultiLineText is="p">
             {trans("callout.activate")}

--- a/client/component/compound/header/activate-me-banner.tsx
+++ b/client/component/compound/header/activate-me-banner.tsx
@@ -3,7 +3,7 @@
 import {faEnvelope, faExclamationCircle} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, MultiLineText, useTrans} from "zographia";
-import {MainContainer} from "/client/component/compound/page";
+import {Banner, BannerBody, BannerIconContainer} from "/client/component/compound/banner";
 import {create} from "/client/component/create";
 import {UserWithDetail} from "/server/internal/skeleton";
 import {useIssueMyActivateToken} from "./activate-me-banner-hook";
@@ -24,20 +24,18 @@ export const ActivateMeBanner = create(
     const issueMyActivateToken = useIssueMyActivateToken();
 
     return (me !== null && !me.activated) ? (
-      <div styleName="root" {...rest}>
-        <MainContainer styleName="container" width="normal">
-          <GeneralIcon styleName="icon" icon={faExclamationCircle}/>
-          <div styleName="content">
-            <MultiLineText is="p">
-              {trans("callout.activate")}
-            </MultiLineText>
-            <Button styleName="button" variant="light" onClick={issueMyActivateToken}>
-              <ButtonIconbag><GeneralIcon icon={faEnvelope}/></ButtonIconbag>
-              {trans("button.issueActivateToken")}
-            </Button>
-          </div>
-        </MainContainer>
-      </div>
+      <Banner {...rest}>
+        <BannerIconContainer icon={faExclamationCircle}/>
+        <BannerBody>
+          <MultiLineText is="p">
+            {trans("callout.activate")}
+          </MultiLineText>
+          <Button styleName="button" variant="light" onClick={issueMyActivateToken}>
+            <ButtonIconbag><GeneralIcon icon={faEnvelope}/></ButtonIconbag>
+            {trans("button.issueActivateToken")}
+          </Button>
+        </BannerBody>
+      </Banner>
     ) : null;
 
   }

--- a/client/component/compound/terms-agreement-banner/terms-agreement-banner.scss
+++ b/client/component/compound/terms-agreement-banner/terms-agreement-banner.scss
@@ -3,38 +3,6 @@
 @use "zographia/source/component/function.scss" as *;
 
 
-.root {
-  @include theme("light") {
-    --background-color: #{leveled-color("red", 0)};
-    --border-color: #{leveled-color("red", 3)};
-    --icon-color: #{leveled-color("red", 5)};
-  }
-}
-
-.root {
-  padding-block: 4zu;
-  background-color: var(--background-color);
-  border-block-end: solid 1zx var(--border-color);
-}
-
-.container {
-  column-gap: 4zu;
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  align-items: center;
-}
-
-.content {
-  row-gap: 3zu;
-  display: flex;
-  flex-direction: column;
-}
-
-.icon {
-  font-size: 10zu;
-  color: var(--icon-color);
-}
-
 .button {
   align-self: flex-start;
 }

--- a/client/component/compound/terms-agreement-banner/terms-agreement-banner.tsx
+++ b/client/component/compound/terms-agreement-banner/terms-agreement-banner.tsx
@@ -4,7 +4,7 @@ import {faCheck, faInfoCircle} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, MultiLineText, useTrans} from "zographia";
 import {Link} from "/client/component/atom/link";
-import {MainContainer} from "/client/component/compound/page/main-container";
+import {Banner, BannerBody, BannerIconContainer} from "/client/component/compound/banner";
 import {create} from "/client/component/create";
 import {TERMS_DEEMED_CONSENT_DATE} from "/client/constant/terms";
 import {useTermsAgreementBanner} from "./terms-agreement-banner-hook";
@@ -24,24 +24,22 @@ export const TermsAgreementBanner = create(
     const dateString = transDate(TERMS_DEEMED_CONSENT_DATE.tz("Asia/Tokyo"), "date");
 
     return (type !== null) ? (
-      <div styleName="root" {...rest}>
-        <MainContainer styleName="container" width="normal">
-          <GeneralIcon styleName="icon" icon={faInfoCircle}/>
-          <div styleName="content">
-            <MultiLineText is="p">
-              {transNode(`message.${type}`, {
-                dateString,
-                termsLink: (parts) => <Link href="/document/legal/terms" scheme="secondary" variant="underline" target="_blank">{parts}</Link>,
-                privacyLink: (parts) => <Link href="/document/legal/privacy" scheme="secondary" variant="underline" target="_blank">{parts}</Link>
-              })}
-            </MultiLineText>
-            <Button styleName="button" variant="light" onClick={handleSubmit}>
-              <ButtonIconbag><GeneralIcon icon={faCheck}/></ButtonIconbag>
-              {trans("button.agree")}
-            </Button>
-          </div>
-        </MainContainer>
-      </div>
+      <Banner {...rest}>
+        <BannerIconContainer icon={faInfoCircle}/>
+        <BannerBody>
+          <MultiLineText is="p">
+            {transNode(`message.${type}`, {
+              dateString,
+              termsLink: (parts) => <Link href="/document/legal/terms" scheme="secondary" variant="underline" target="_blank">{parts}</Link>,
+              privacyLink: (parts) => <Link href="/document/legal/privacy" scheme="secondary" variant="underline" target="_blank">{parts}</Link>
+            })}
+          </MultiLineText>
+          <Button styleName="button" variant="light" onClick={handleSubmit}>
+            <ButtonIconbag><GeneralIcon icon={faCheck}/></ButtonIconbag>
+            {trans("button.agree")}
+          </Button>
+        </BannerBody>
+      </Banner>
     ) : null;
 
   }

--- a/client/component/compound/terms-agreement-banner/terms-agreement-banner.tsx
+++ b/client/component/compound/terms-agreement-banner/terms-agreement-banner.tsx
@@ -25,7 +25,7 @@ export const TermsAgreementBanner = create(
 
     return (type !== null) ? (
       <Banner {...rest}>
-        <BannerIconContainer icon={faInfoCircle}/>
+        <BannerIconContainer><GeneralIcon icon={faInfoCircle}/></BannerIconContainer>
         <BannerBody>
           <MultiLineText is="p">
             {transNode(`message.${type}`, {


### PR DESCRIPTION
TermsAgreementBanner と ActivateMeBanner でほぼ同一だったレイアウト・
スタイルを、compound の Banner コンポーネントに切り出した。
Banner はサブコンポーネントとして左側アイコンの BannerIconContainer と
右側メイン部分の BannerBody を受け取る形とし、両バナーはこれを使うように
変更した。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VAd518QoAL9rej3PmzVEUX