### PR TITLE
メッセージファイル整備: 20260703

### DIFF
--- a/client/message/en.yml
+++ b/client/message/en.yml
@@ -608,6 +608,19 @@ invitationList:
   button:
     accept: "Accept"
     reject: "Decline"
+issueUserResetTokenForm:
+  label:
+    name: "Username"
+    email: "Email address"
+  error:
+    nameRequired: >-
+      Enter a username.
+    emailInvalid: >-
+      Enter a valid email address.
+    emailRequired: >-
+      Enter an email address.
+  button:
+    confirm: "Send"
 loginForm:
   label:
     name: "Username"
@@ -687,19 +700,6 @@ registerForm:
       Enter a password.
     agreeRequired: >-
       In order to use this application, you must read and agree to the privacy policy.
-issueUserResetTokenForm:
-  label:
-    name: "Username"
-    email: "Email address"
-  error:
-    nameRequired: >-
-      Enter a username.
-    emailInvalid: >-
-      Enter a valid email address.
-    emailRequired: >-
-      Enter an email address.
-  button:
-    confirm: "Send"
 resetUserPasswordForm:
   label:
     password: "New password"

--- a/client/message/eo.yml
+++ b/client/message/eo.yml
@@ -608,6 +608,19 @@ invitationList:
   button:
     accept: "Akcepti"
     reject: "Malakcepti"
+issueUserResetTokenForm:
+  label:
+    name: "Salutnomo"
+    email: "Retpoŝta adreso"
+  error:
+    nameRequired: >-
+      Enigu salutnomon.
+    emailInvalid: >-
+      Enigu validan retpoŝtan adreson.
+    emailRequired: >-
+      Enigu retpoŝtan adreson.
+  button:
+    confirm: "Sendi"
 loginForm:
   label:
     name: "Salutnomo"
@@ -687,19 +700,6 @@ registerForm:
       Enigu pasvorton.
     agreeRequired: >-
       Por uzi tiun aplikaĵon, vi devas legi kaj konsenti pri la privateca politiko.
-issueUserResetTokenForm:
-  label:
-    name: "Salutnomo"
-    email: "Retpoŝta adreso"
-  error:
-    nameRequired: >-
-      Enigu salutnomon.
-    emailInvalid: >-
-      Enigu validan retpoŝtan adreson.
-    emailRequired: >-
-      Enigu retpoŝtan adreson.
-  button:
-    confirm: "Sendi"
 resetUserPasswordForm:
   label:
     password: "Nova pasvorto"

--- a/client/message/ja.yml
+++ b/client/message/ja.yml
@@ -609,6 +609,19 @@ invitationList:
   button:
     accept: "承認"
     reject: "拒否"
+issueUserResetTokenForm:
+  label:
+    name: "ユーザー ID"
+    email: "メールアドレス"
+  error:
+    nameRequired: >-
+      ユーザー ID を入力してください。
+    emailInvalid: >-
+      正しい形式のメールアドレスを入力してください。
+    emailRequired: >-
+      メールアドレスを入力してください。
+  button:
+    confirm: "送信"
 loginForm:
   label:
     name: "ユーザー ID"
@@ -687,19 +700,6 @@ registerForm:
       パスワードを入力してください。
     agreeRequired: >-
       このアプリケーションを利用していただくには、プライバシーポリシーをお読みいただき同意していただく必要があります。
-issueUserResetTokenForm:
-  label:
-    name: "ユーザー ID"
-    email: "メールアドレス"
-  error:
-    nameRequired: >-
-      ユーザー ID を入力してください。
-    emailInvalid: >-
-      正しい形式のメールアドレスを入力してください。
-    emailRequired: >-
-      メールアドレスを入力してください。
-  button:
-    confirm: "送信"
 resetUserPasswordForm:
   label:
     password: "新しいパスワード"


### PR DESCRIPTION
client アプリの国際化メッセージファイル (`client/message/ja.yml`, `en.yml`, `eo.yml`) を `maintain-messages` skill で整備しました。

## 未設定メッセージの追加

未設定キーは 0 件でした。追加作業はありませんでした。

## 並び替え

各ファイルを以下の体裁に整えました (メッセージ本文は変更していません)。

- セクションを `toast` → `atom` → `compound` → `form` → `page` → `other` の順に整列。
- 各セクション内のルートキーをアルファベット順に整列 (`toast` は `success` → `error` の固定順、YAML アンカー依存は尊重)。
- 実際の変更は `issueUserResetTokenForm` ブロックの位置移動のみです (中身は同一)。

## 補足

- `<NOT SET>` のキーはありません。
- テンプレートリテラルで動的に組み立てられるキーは自動解決できないため対象外です。
- `[スコープ未特定]` の参照は 0 件でした。