### PR TITLE
maintain-messages skill の改行コード不具合修正と事前確認の改善

### DIFF
--- a/.claude/skills/maintain-messages/SKILL.md
+++ b/.claude/skills/maintain-messages/SKILL.md
@@ -64,14 +64,19 @@ git status
 - **`develop` ブランチにいること**を確認する。違う場合は中断してユーザーに報告する (勝手に切り替えない)。
 - **working tree が clean であること**を確認する。未コミットの変更がある場合は中断して報告する。
 
-この後で、さらに**未マージの整備 PR がないこと**も確認する。
-以下で `maintenance/messages-*` の open PR を調べる。
+この後で、さらに**未マージの整備ブランチがないこと**も確認する。
+リモートに残っている `maintenance/messages-*` ブランチを調べる。
 ```bash
-gh pr list --state open --base develop --json number,title,headRefName \
-  --jq '.[] | select(.headRefName | startswith("maintenance/messages-")) | "#\(.number) \(.title) (\(.headRefName))"'
+git ls-remote --heads origin 'maintenance/messages-*'
 ```
-出力があれば、前回以前の整備 PR がまだマージされていない。
+本リポジトリは PR マージ時に head ブランチを自動削除する運用のため、ここに残っているのは**未マージの整備ブランチだけ**になる。
+今日の日付のブランチ (Step 2 で作るもの) 以外が 1 つでも出力されたら、前回以前の整備 PR がまだマージされていない。
 `develop` から切り直すと同じ変更を重複して PR 化してしまい、コンフリクトの原因になるので、**ここで中断し、その PR を先にマージもしくはクローズするようユーザーに促す**。
+
+> ⚠️ **GitHub の PR 一覧 API (`gh pr list` や `list_pull_requests`) は使わない**。
+> 一覧取得はキャッシュにより結果が古くなることがあり、マージ済みの PR を `open` と誤って返す場合がある。
+> リモートブランチの有無はローカル git が返す確定情報なので、こちらを判定の根拠にする。
+> 万一ブランチ自動削除が無効な運用に変わっていた場合の保険として、出力された各ブランチが `git merge-base --is-ancestor origin/<branch> origin/develop` で `develop` の先祖 (= マージ済み) かどうかを確認し、マージ済みのものは無視してよい。
 
 全て満たす場合のみ次に進む。
 

--- a/.claude/skills/maintain-messages/SKILL.md
+++ b/.claude/skills/maintain-messages/SKILL.md
@@ -74,9 +74,9 @@ git ls-remote --heads origin 'maintenance/messages-*'
 `develop` から切り直すと同じ変更を重複して PR 化してしまい、コンフリクトの原因になるので、**ここで中断し、その PR を先にマージもしくはクローズするようユーザーに促す**。
 
 > ⚠️ **GitHub の PR 一覧 API (`gh pr list` や `list_pull_requests`) は使わない**。
-> 一覧取得はキャッシュにより結果が古くなることがあり、マージ済みの PR を `open` と誤って返す場合がある。
+> 一覧取得はキャッシュにより結果が古くなることがあり、マージ済みの PR を open と誤って返す場合がある。
 > リモートブランチの有無はローカル git が返す確定情報なので、こちらを判定の根拠にする。
-> 万一ブランチ自動削除が無効な運用に変わっていた場合の保険として、出力された各ブランチが `git merge-base --is-ancestor origin/<branch> origin/develop` で `develop` の先祖 (= マージ済み) かどうかを確認し、マージ済みのものは無視してよい。
+> 万一ブランチ自動削除が無効な運用に変わっていた場合の保険として、出力された各ブランチが `git merge-base --is-ancestor origin/<branch> origin/develop` で `develop` の先祖 (＝マージ済み) かどうかを確認し、マージ済みのものは無視して良い。
 
 全て満たす場合のみ次に進む。
 

--- a/.claude/skills/maintain-messages/scripts/reorder-messages.ts
+++ b/.claude/skills/maintain-messages/scripts/reorder-messages.ts
@@ -61,7 +61,7 @@ function reorderFile(lang: string, namespaceSections: Map<string, Section>): voi
       output.push(...block.lines);
     }
   });
-  const eol = "\r\n";
+  const eol = raw.includes("\r\n") ? "\r\n" : "\n";
   let result = output.join(eol);
   if (hadTrailingNewline) {
     result += eol;

--- a/.claude/skills/maintain-messages/scripts/reorder-messages.ts
+++ b/.claude/skills/maintain-messages/scripts/reorder-messages.ts
@@ -61,7 +61,7 @@ function reorderFile(lang: string, namespaceSections: Map<string, Section>): voi
       output.push(...block.lines);
     }
   });
-  const eol = raw.includes("\r\n") ? "\r\n" : "\n";
+  const eol = (raw.includes("\r\n")) ? "\r\n" : "\n";
   let result = output.join(eol);
   if (hadTrailingNewline) {
     result += eol;


### PR DESCRIPTION
`maintain-messages` skill の 2 点を修正します。

## 1. reorder スクリプトの改行コード変換不具合

`reorder-messages.ts` が並び替え結果を書き出す際、行末を `"\r\n"` (CRLF) にハードコードしていました。元のメッセージファイルは LF のため、並び替えのたびに**全行が LF → CRLF に変換**され、本来わずかな並び替え差分 (数十行) が全行 (約 4449 行) の差分に膨れ上がっていました。

元ファイルの改行コードを検出して保持するよう修正しました (`raw.includes("\r\n") ? "\r\n" : "\n"`)。これにより、以降の並び替え PR は実質的な差分だけになります。

## 2. Step 1 の未マージ整備 PR 確認方法の改善

Step 1 では「前回以前の未マージ整備 PR が残っていないか」を GitHub の PR 一覧 API (`gh pr list`) で確認していましたが、この一覧はキャッシュにより古くなることがあり、**マージ済みの PR を `open` と誤って返す**ケースがありました (実際に誤検知が発生)。

リモートブランチの有無を見る `git ls-remote --heads origin 'maintenance/messages-*'` ベースの判定に変更しました。本リポジトリは PR マージ時に head ブランチを自動削除するため、ここに残るのは未マージのブランチだけであり、ローカル git の確定情報で判定できます。ブランチ自動削除が無効な運用に変わった場合の保険として、`git merge-base --is-ancestor` でマージ済みブランチを除外する手順も併記しました。

## 補足

- メッセージファイル (`client/message/*.yml`) 自体の変更は含みません。並び替えの PR (#131) とは分離しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFo8Qi5DBtgQ9tS2tNwqmh)_