### PR TITLE
メッセージファイル整備: 20260710

### DIFF
--- a/client/message/ja.yml
+++ b/client/message/ja.yml
@@ -333,6 +333,7 @@ apiCredentialList:
   caution: >-
     API キーを後から確認することはできません。
     今の段階でコピーして保存しておいてください。
+  empty: "<NOT SET>"
   toast:
     copy: >-
       API キーをコピーしました。

--- a/client/message/ja.yml
+++ b/client/message/ja.yml
@@ -333,7 +333,7 @@ apiCredentialList:
   caution: >-
     API キーを後から確認することはできません。
     今の段階でコピーして保存しておいてください。
-  empty: "<NOT SET>"
+  empty: "API キーは発行されていません"
   toast:
     copy: >-
       API キーをコピーしました。


### PR DESCRIPTION
client アプリの国際化メッセージファイル (`client/message/ja.yml`, `en.yml`, `eo.yml`) を `maintain-messages` skill で整備しました。

## 未設定メッセージの追加
コードが参照しているのにメッセージファイルに未設定だったキーを追加しました。

### `<NOT SET>` で追加 (翻訳元が `ja.yml` にもなかったもの)
- `apiCredentialList.empty` (`ja.yml` のみ。`en.yml` / `eo.yml` には既存の値あり)

### 翻訳して追加 (`ja.yml` に翻訳元があったもの)
- なし

> ⚠️ `<NOT SET>` のままのキーは実際のメッセージではありません。別途、実際のメッセージへ置き換える必要があります。
> 今回は `en.yml` / `eo.yml` に対応する値 (英: "You have not issued any API keys yet" / エスペラント: "Vi ankoraŭ ne eldonis iun ajn API-ŝlosilon") が存在するため、これらを参考に日本語のメッセージを埋めてください。

## 並び替え
各ファイルを以下の体裁で確認しました (メッセージ本文は変更していません)。

- セクションを `toast` → `atom` → `compound` → `form` → `page` → `other` の順に整列。
- 各セクション内のルートキーをアルファベット順に整列 (`toast` は `success` → `error` の固定順、YAML アンカー依存は尊重)。
- 今回は並び替えによる実質的な変更はありませんでした (既に整列済み)。実際の差分は `ja.yml` への 1 行追加のみです。

## 補足
- `[スコープ未特定]` の参照は 0 件でした。
- テンプレートリテラルで動的に組み立てられるキーは自動解決できないため対象外です。

---
_Generated by [Claude Code](https://claude.ai/code/session_015xQaEvqtcMt7bP9Tdiw7DA)_