### PR TITLE
クエリの使用状況に合わせて MongoDB のインデックスを追加

### DIFF
--- a/server/model/article/old-article.ts
+++ b/server/model/article/old-article.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -13,6 +14,8 @@ import {LogUtil} from "/server/util/log";
 
 
 @modelOptions({schemaOptions: {collection: "oldArticles"}})
+@index({"dictionary": 1, "number": 1})
+@index({"deletedDate": 1})
 export class OldArticleSchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/dictionary-parameter/dictionary-parameter.ts
+++ b/server/model/dictionary-parameter/dictionary-parameter.ts
@@ -13,9 +13,9 @@ export abstract class DictionaryParameter {
     const mode = order.mode;
     const directionSign = (order.direction === "ascending") ? "" : "-";
     if (mode === "updatedDate") {
-      return `${directionSign}updatedDate _id`;
+      return `${directionSign}updatedDate ${directionSign}_id`;
     } else if (mode === "createdDate") {
-      return `${directionSign}createdDate _id`;
+      return `${directionSign}createdDate ${directionSign}_id`;
     } else {
       const dummy = mode satisfies never;
       throw new Error("cannot happen");

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   isDocument,
   modelOptions,
   prop
@@ -47,6 +48,9 @@ export const DictionaryVisibilityUtil = LiteralUtilType.create(DICTIONARY_VISIBI
 
 
 @modelOptions({schemaOptions: {collection: "dictionaries", minimize: false}})
+@index({"paramName": 1}, {"sparse": true})
+@index({"visibility": 1, "updatedDate": -1, "number": -1})
+@index({"user": 1})
 export class DictionarySchema {
 
   @prop({required: true, ref: "UserSchema"})

--- a/server/model/example-parameter/normal-example-parameter.ts
+++ b/server/model/example-parameter/normal-example-parameter.ts
@@ -26,7 +26,7 @@ export class NormalExampleParameter extends ExampleParameter {
   public createQuery(dictionary: Dictionary): QueryLike<Array<Example>, Example> {
     const keys = ExampleParameter.createKeys(this.mode);
     const needle = ExampleParameter.createNeedle(this.text, this.type, this.options.ignore);
-    const sortKey = "-createdDate -number _id";
+    const sortKey = "-createdDate -number -_id";
     const disjunctFilters = keys.map((key) => ExampleModel.find().where(key, needle).getFilter());
     const query = ExampleModel.find().where("dictionary", dictionary["_id"]).or(disjunctFilters).sort(sortKey);
     return query;

--- a/server/model/example/example.ts
+++ b/server/model/example/example.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -21,6 +22,10 @@ import {LinkedExampleOfferSchema} from "../example-offer/linked-example-offer";
 
 
 @modelOptions({schemaOptions: {collection: "examples"}})
+@index({"dictionary": 1, "number": 1})
+@index({"dictionary": 1, "createdDate": -1, "number": -1, "_id": -1})
+@index({"dictionary": 1, "words.number": 1})
+@index({"offer.catalog": 1, "offer.number": 1})
 export class ExampleSchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/example/old-example.ts
+++ b/server/model/example/old-example.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -15,6 +16,8 @@ import {LogUtil} from "/server/util/log";
 
 
 @modelOptions({schemaOptions: {collection: "oldExamples"}})
+@index({"dictionary": 1, "number": 1})
+@index({"deletedDate": 1})
 export class OldExampleSchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/history.ts
+++ b/server/model/history.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -13,6 +14,7 @@ import {QueryRange} from "/server/util/query";
 
 
 @modelOptions({schemaOptions: {collection: "histories"}})
+@index({"dictionary": 1, "date": -1})
 export class HistorySchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/member/member.ts
+++ b/server/model/member/member.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -14,6 +15,8 @@ import {User, UserSchema} from "/server/model/user/user";
 
 
 @modelOptions({schemaOptions: {collection: "members"}})
+@index({"dictionary": 1, "user": 1, "authority": 1})
+@index({"user": 1, "authority": 1})
 export class MemberSchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/user/user.ts
+++ b/server/model/user/user.ts
@@ -3,6 +3,7 @@
 import {
   DocumentType,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -18,6 +19,7 @@ import {EMAIL_REGEXP, IDENTIFIER_REGEXP, validatePassword} from "/server/util/va
 
 
 @modelOptions({schemaOptions: {collection: "users"}})
+@index({"email": 1})
 export class UserSchema {
 
   @prop({required: true, unique: true, validate: IDENTIFIER_REGEXP})

--- a/server/model/word-parameter/word-parameter.ts
+++ b/server/model/word-parameter/word-parameter.ts
@@ -73,13 +73,13 @@ export abstract class WordParameter {
     const mode = order.mode;
     const directionSign = (order.direction === "ascending") ? "" : "-";
     if (mode === "unicode") {
-      return `${directionSign}name _id`;
+      return `${directionSign}name ${directionSign}_id`;
     } else if (mode === "custom") {
-      return `${directionSign}sortString _id`;
+      return `${directionSign}sortString ${directionSign}_id`;
     } else if (mode === "updatedDate") {
-      return `${directionSign}updatedDate _id`;
+      return `${directionSign}updatedDate ${directionSign}_id`;
     } else if (mode === "createdDate") {
-      return `${directionSign}createdDate _id`;
+      return `${directionSign}createdDate ${directionSign}_id`;
     } else {
       const dummy = mode satisfies never;
       throw new Error("cannot happen");

--- a/server/model/word/old-word.ts
+++ b/server/model/word/old-word.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -14,6 +15,8 @@ import {LogUtil} from "/server/util/log";
 
 
 @modelOptions({schemaOptions: {collection: "oldWords"}})
+@index({"dictionary": 1, "number": 1})
+@index({"deletedDate": 1})
 export class OldWordSchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/word/word.ts
+++ b/server/model/word/word.ts
@@ -1,4 +1,4 @@
-//
+/* eslint-disable @typescript-eslint/naming-convention */
 
 import {
   DocumentType,
@@ -23,7 +23,6 @@ import {LogUtil} from "/server/util/log";
 @index({"dictionary": 1, "name": 1, "_id": 1})
 @index({"dictionary": 1, "updatedDate": -1, "_id": -1})
 @index({"dictionary": 1, "createdDate": -1, "_id": -1})
-// eslint-disable-next-line @typescript-eslint/naming-convention
 @index({"dictionary": 1, "sections.relations.number": 1})
 export class WordSchema {
 

--- a/server/model/word/word.ts
+++ b/server/model/word/word.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -18,6 +19,12 @@ import {LogUtil} from "/server/util/log";
 
 
 @modelOptions({schemaOptions: {collection: "words"}})
+@index({"dictionary": 1, "number": 1})
+@index({"dictionary": 1, "name": 1, "_id": 1})
+@index({"dictionary": 1, "updatedDate": -1, "_id": -1})
+@index({"dictionary": 1, "createdDate": -1, "_id": -1})
+// eslint-disable-next-line @typescript-eslint/naming-convention
+@index({"dictionary": 1, "sections.relations.number": 1})
 export class WordSchema {
 
   @prop({required: true, ref: "DictionarySchema"})


### PR DESCRIPTION
## 概要
サーバーサイドの全クエリ呼び出し (`server/model/` 内 + serializer) を棚卸しし、クエリの使用状況に合わせて MongoDB のインデックスを追加しました。合わせて、インデックスが降順ソートにも効くように、ソートキーのタイブレーカーの方向を修正しています。

## 追加したインデックス
| コレクション | インデックス |
|---|---|
| words | `{dictionary, number}` / `{dictionary, name, _id}` / `{dictionary, updatedDate, _id}` / `{dictionary, createdDate, _id}` / `{dictionary, sections.relations.number}` |
| examples | `{dictionary, number}` / `{dictionary, createdDate, number, _id}` / `{dictionary, words.number}` / `{offer.catalog, offer.number}` |
| oldWords / oldExamples / oldArticles | `{dictionary, number}` / `{deletedDate}` |
| dictionaries | `{paramName}` (sparse) / `{visibility, updatedDate, number}` / `{user}` |
| members | `{dictionary, user, authority}` / `{user, authority}` |
| histories | `{dictionary, date}` |
| users | `{email}` |

特に効果が大きいのは、単語作成のたびに走る oldWords / oldExamples の採番クエリ (現状フルコレクションスキャン) と、辞書ページ表示のたびに走る words の取得・ソートです。

## ソートキーの修正
`createSortKey` が降順時に「主キー降順 + `_id` 昇順」という方向混在のソートを生成しており、このままではインデックスの逆順走査が効かないため、降順時はタイブレーカーも `-_id` になるよう揃えました (word-parameter / dictionary-parameter / normal-example-parameter)。同順位のドキュメントの並びが従来と逆になりますが、ページネーションの安定性は保たれます。

## 補足
- インデックスは Typegoose の `@index()` で宣言し、反映は Mongoose の autoIndex (起動時の createIndex) に任せる方針です。本番の初回起動時に大きいコレクションのビルド負荷がかかる点に留意してください (必要ならデプロイ前に mongosh で手動 createIndex しておけば冪等にスキップされます)。
- `{dictionary, number}` に unique 制約は付けていません (アップロードの insertMany がファイル由来のデータをそのまま挿入するため)。
- 検証: `npm run lint` (エラーなし・既存警告のみ) / `tsc --noEmit --skipLibCheck` 通過。ローカル MongoDB での explain 検証は未実施です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)