### PR TITLE
インデックス整備: 20260717

### DIFF
--- a/server/model/article/article.ts
+++ b/server/model/article/article.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -16,6 +17,8 @@ import {LogUtil} from "/server/util/log";
 
 
 @modelOptions({schemaOptions: {collection: "articles"}})
+@index({"dictionary": 1, "number": 1})
+@index({"dictionary": 1, "updatedDate": -1, "_id": -1})
 export class ArticleSchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/dictionary/dictionary.ts
+++ b/server/model/dictionary/dictionary.ts
@@ -50,6 +50,9 @@ export const DictionaryVisibilityUtil = LiteralUtilType.create(DICTIONARY_VISIBI
 @modelOptions({schemaOptions: {collection: "dictionaries", minimize: false}})
 @index({"paramName": 1}, {"sparse": true})
 @index({"visibility": 1, "updatedDate": -1, "number": -1})
+@index({"visibility": 1, "createdDate": -1, "updatedDate": -1, "number": -1})
+@index({"visibility": 1, "updatedDate": -1, "_id": -1})
+@index({"visibility": 1, "createdDate": -1, "_id": -1})
 @index({"user": 1})
 export class DictionarySchema {
 

--- a/server/model/example-offer-parameter/normal-example-offer-parameter.ts
+++ b/server/model/example-offer-parameter/normal-example-offer-parameter.ts
@@ -18,7 +18,7 @@ export class NormalExampleOfferParameter extends ExampleOfferParameter {
 
   public createQuery(): QueryLike<Array<ExampleOffer>, ExampleOffer> {
     if (this.catalog !== null) {
-      const sortKey = (this.catalog === "zpdicDaily") ? "catalog -number _id" : "catalog number _id";
+      const sortKey = (this.catalog === "zpdicDaily") ? "catalog -number -_id" : "catalog number _id";
       const query = ExampleOfferModel.where("catalog", this.catalog).sort(sortKey);
       return query;
     } else {

--- a/server/model/example-offer/example-offer.ts
+++ b/server/model/example-offer/example-offer.ts
@@ -3,6 +3,7 @@
 import {
   DocumentType,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -15,6 +16,7 @@ import {QueryRange, WithSize} from "/server/util/query";
 
 
 @modelOptions({schemaOptions: {collection: "exampleOffers"}})
+@index({"catalog": 1, "number": 1, "_id": 1})
 export class ExampleOfferSchema {
 
   @prop({required: true})

--- a/server/model/invitation.ts
+++ b/server/model/invitation.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   isDocument,
   modelOptions,
   prop
@@ -21,6 +22,8 @@ export const InvitationTypeUtil = LiteralUtilType.create(INVITATION_TYPES);
 
 
 @modelOptions({schemaOptions: {collection: "invitations"}})
+@index({"dictionary": 1, "user": 1, "type": 1})
+@index({"type": 1, "user": 1, "createdDate": -1})
 export class InvitationSchema {
 
   @prop({required: true, enum: INVITATION_TYPES})

--- a/server/model/member/member.ts
+++ b/server/model/member/member.ts
@@ -15,7 +15,7 @@ import {User, UserSchema} from "/server/model/user/user";
 
 
 @modelOptions({schemaOptions: {collection: "members"}})
-@index({"dictionary": 1, "user": 1, "authority": 1})
+@index({"dictionary": 1, "authority": 1, "user": 1})
 @index({"user": 1, "authority": 1})
 export class MemberSchema {
 

--- a/server/model/proposal.ts
+++ b/server/model/proposal.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -12,6 +13,7 @@ import {QueryRange, WithSize} from "/server/util/query";
 
 
 @modelOptions({schemaOptions: {collection: "commissions"}})
+@index({"dictionary": 1, "createdDate": -1, "_id": -1})
 export class ProposalSchema {
 
   @prop({required: true, ref: "DictionarySchema"})

--- a/server/model/user/api-credential.ts
+++ b/server/model/user/api-credential.ts
@@ -4,6 +4,7 @@ import {
   DocumentType,
   Ref,
   getModelForClass,
+  index,
   modelOptions,
   prop
 } from "@typegoose/typegoose";
@@ -17,6 +18,7 @@ const DEFAULT_API_CREDENTIAL_LIMIT = 10;
 
 
 @modelOptions({schemaOptions: {collection: "apiCredentials"}})
+@index({"user": 1})
 export class ApiCredentialSchema {
 
   @prop({required: true, ref: "UserSchema"})

--- a/server/model/user/user.ts
+++ b/server/model/user/user.ts
@@ -1,4 +1,4 @@
-//
+/* eslint-disable @typescript-eslint/naming-convention */
 
 import {
   DocumentType,
@@ -20,6 +20,8 @@ import {EMAIL_REGEXP, IDENTIFIER_REGEXP, validatePassword} from "/server/util/va
 
 @modelOptions({schemaOptions: {collection: "users"}})
 @index({"email": 1})
+@index({"activateToken.name": 1}, {"sparse": true})
+@index({"resetToken.name": 1}, {"sparse": true})
 export class UserSchema {
 
   @prop({required: true, unique: true, validate: IDENTIFIER_REGEXP})

--- a/server/model/word/old-word.ts
+++ b/server/model/word/old-word.ts
@@ -15,7 +15,7 @@ import {LogUtil} from "/server/util/log";
 
 
 @modelOptions({schemaOptions: {collection: "oldWords"}})
-@index({"dictionary": 1, "number": 1})
+@index({"dictionary": 1, "number": 1, "updatedDate": -1})
 @index({"deletedDate": 1})
 export class OldWordSchema {
 


### PR DESCRIPTION
## 概要
`server/` 内の全クエリ呼び出しを棚卸しし、Typegoose の `@index` 宣言と突き合わせて整備しました。
コード変更はインデックス設定 (`@index`) の追加・削除、および1箇所のみ許容されているソートのタイブレーカー (`_id`) の方向修正に限定しており、クエリの絞り込み条件・取得内容・アプリの挙動は変えていません。

## 追加したインデックス

### `articles` (`@index` が1つもない状態でした)
- `{dictionary: 1, number: 1}`
  - `ArticleModel.findOne().where("dictionary", ...).where("number", ...)` (`article.ts` の `edit`/`discard`、`dictionary.ts` の `fetchOneArticleByNumber`) — 記事の編集・削除のたびに実行される検索
  - `ArticleModel.find().where("dictionary", ...).select("number").sort("-number").limit(1)` (`fetchNextNumber`) — 新規記事作成のたびに実行
- `{dictionary: 1, updatedDate: -1, _id: -1}`
  - `dictionary.ts` の `searchArticles` (`find().where("dictionary", ...).sort("-updatedDate")`, `restrictWithSize` でページング) — 記事一覧ページで実行。`words`/`examples` と同じ形の複合インデックス (末尾の `_id` はタイブレーカー用、コード側の `sort` 呼び出しは変更していません)

### `oldWords`
- `{dictionary: 1, number: 1, updatedDate: -1}` (既存の `{dictionary: 1, number: 1}` を置き換え)
  - `dictionary.ts` の `fetchOldWords` (`find().where("dictionary", ...).where("number", ...).sort("-updatedDate")`) — 単語の編集履歴閲覧時に実行。旧インデックスには `updatedDate` が含まれておらず、ソートがインデックスで賄えていませんでした
  - 既存の `word.ts` の `fetchNextNumber` (`dictionary` 等価 + `number` 降順ソート) も引き続きこの新インデックスでカバーされます

### `dictionaries`
- `{visibility: 1, createdDate: -1, updatedDate: -1, number: -1}`
  - `dictionary.ts` の `fetch(order)` で `order === "createdDate"` のときの `sort("-createdDate -updatedDate -number")` — 公開辞書一覧の「作成日順」ソート。既存の `{visibility, updatedDate, number}` は「更新日順」(デフォルト) にしか対応しておらず、作成日順のソートにはインデックスが効いていませんでした
- `{visibility: 1, updatedDate: -1, _id: -1}` / `{visibility: 1, createdDate: -1, _id: -1}`
  - `DictionaryParameter.createSortKey` (`_id` をタイブレーカーに使う) を経由する辞書検索 (`normal-dictionary-parameter.ts` の `createQuery`、URL パラメータ `orderMode`/`orderDirection` で両モードとも到達可能) — こちらはタイブレーカーが `number` ではなく `_id` のため、既存の `{visibility, updatedDate, number}` とは別に必要でした

### `exampleOffers` (`@index` が1つもない状態でした)
- `{catalog: 1, number: 1, _id: 1}`
  - `example-offer.ts` の `fetchOneByNumber` (`catalog`+`number` 等価)、`fetchDailyNextNumber` (`catalog` 等価 + `number` 降順ソート)
  - `NormalExampleOfferParameter.createQuery` (`catalog` 等価 + `number`/`_id` ソート、`catalog === null` のときは全件を `catalog number _id` 昇順でソート) — 用例オファーの一覧・検索ページで実行 (`restrictWithSize` によるページング込み)
- **コード変更 1件 (タイブレーカーの方向のみ)**: `normal-example-offer-parameter.ts` で `catalog === "zpdicDaily"` のときのソートキーが `"catalog -number _id"` (`number` は降順、タイブレーカーの `_id` だけ昇順) という方向混在になっており、単一のインデックスでは処理できない形でした。タイブレーカー `_id` の方向だけを `-_id` (降順) に変更し、`catalog`/`number` の絞り込み・ソート自体は変えていません。`number` は辞書内の単語番号などと同様カタログ内で一意である前提のため、同順位のドキュメントは実質発生せず、並び順への影響はありません。

### `invitations` (`@index` が1つもない状態でした)
- `{dictionary: 1, user: 1, type: 1}`
  - `invitation.ts` の `assure` (招待作成時の重複チェック、`type`+`dictionary`+`user` 等価)
- `{type: 1, user: 1, createdDate: -1}`
  - `invitation.ts` の `fetchByUser` (`type`+`user` 等価 + `createdDate` 降順ソート) — 招待一覧ページで実行

### `commissions` (Proposal モデル、`@index` が1つもない状態でした)
- `{dictionary: 1, createdDate: -1, _id: -1}`
  - `proposal.ts` の `fetchByDictionary` (`find().where("dictionary", ...).sort("-createdDate")`, `restrictWithSize` でページング) — 編集案一覧ページで実行

### `apiCredentials` (`@index` が1つもない状態でした)
- `{user: 1}`
  - `api-credential.ts` の `issue` (発行数チェック)・`fetchByUser` (一覧)・`user.ts` の `discard` (ユーザー削除時のカスケード削除) — いずれも `user` 等価条件のみ

### `members`
- `{dictionary: 1, authority: 1, user: 1}` (既存の `{dictionary: 1, user: 1, authority: 1}` をフィールド順入れ替え)
  - `member.ts` の `fetchByDictionary` (`dictionary`+`authority` のみ等価、`user` は条件に含まれない) が、旧フィールド順だと `user` が間に挟まるため `dictionary` までしかインデックスの絞り込みに使えていませんでした。`authority` を2番目に上げることで `existMember` (`dictionary`+`user`+`authority` の3等価、フィールド順に依存しない) は変わらずカバーしつつ、`fetchByDictionary` も2フィールド分の絞り込みが効くようになります

### `users`
- `{"activateToken.name": 1}` (sparse) / `{"resetToken.name": 1}` (sparse)
  - `user.ts` の `activate` (`findOne().where("activateToken.name", ...)`)・`resetPassword` (`findOne().where("resetToken.name", ...)`) — アカウント有効化・パスワードリセットのリンクを踏むたびに実行される認証系のルックアップですが、インデックスが無くコレクション全件スキャンになっていました。両フィールドともトークン発行中のユーザーにしか値がないため `sparse: true` を付けています

## 削除した `@index` (手動 `dropIndex` が必要です)

`@index` の削除はコード上の宣言を消しても DB のインデックス自体は自動では消えないため、以下を mongosh 等で実行してください。

```js
// oldWords: {dictionary:1, number:1} → {dictionary:1, number:1, updatedDate:-1} に統合
db.oldWords.dropIndex({dictionary: 1, number: 1});

// members: {dictionary:1, user:1, authority:1} → {dictionary:1, authority:1, user:1} にフィールド順を変更
db.members.dropIndex({dictionary: 1, user: 1, authority: 1});
```

## 手動確認事項 (自動では対応できなかった項目)

- 上記の `dropIndex` 2件は本 PR マージ後に手動実行してください。
- ローカル MongoDB での `explain("executionStats")` による効果検証は行っていません。
- 反映後しばらくしてから `db.<collection>.aggregate([{$indexStats: {}}])` で実際に使われているかを確認し、使われていなければ次回整備での削除候補にしてください。
- **今回インデックスの追加を見送った箇所** (設計が非自明、または優先度が低いと判断したもの):
  - `dictionaries.fetchByUser` / `fetchInvolvedByMe` (`dictionary.ts`) — `user` 等価と `_id in [...]` を `$or` で組み合わせた上で `{updatedDate:-1, number:-1}` にソートしており、`_id in` 側の分岐がインデックスでのソート適用を難しくしています。`explain()` での実測をおすすめします。
  - `oldDictionaries` — `@index` が無く `fetchNextNumber` 用の全件 `sort("-number").limit(1)` がありますが、辞書作成時のみ発生する低頻度な処理かつ小規模コレクションのため見送りました。
  - `users.suggest` (`Fuse.js` によるあいまい検索) — フィルタ無しの全件取得が前提の設計のため、インデックスでは対応できません。
  - `word-parameter`/`example-parameter`/`normal-dictionary-parameter` の正規表現検索対象フィールド (`name`, `sentence`, `translation`, `tags` など) — 大小無視の正規表現検索が中心のためインデックスの範囲スキャンが効かず、既存方針通り対象外としています。
- `WordOrder` の `"custom"` モード (`sortString` フィールドでのソート) は `word-parameter.ts` にソートキー生成コードがありますが、`sortString` というフィールド自体が `WordSchema` に存在せず (grep で `word-parameter.ts` 以外どこにも出現しません)、実質未実装の機能に見えます。インデックス云々の前にコード側の実装状況をご確認ください (本 PR では手を加えていません)。
- `unique: true` について見直しが必要そうな箇所は見つかりませんでした。

## 検証について

この実行環境では `@fortawesome/pro-*` 系パッケージ (Font Awesome Pro, 認証が必要) が `zographia` パッケージの依存関係に含まれているため `npm install` が完了せず、`eslint`/`tsc` を実行できませんでした。代わりに、変更した各スキーマファイルについて参照しているフィールド名がすべて実在すること、`@index` 内のプロパティ名のクオート・`typegoose` インポートのアルファベット順・ドット付きキーに対する `eslint-disable` の付与など、既存コードの規約に沿っていることを手動で確認しています。可能であれば、マージ前に手元の環境で `npm run lint` と `npx tsc --noEmit --skipLibCheck` の実行をお願いします。


---
_Generated by [Claude Code](https://claude.ai/code/session_01CBYRz4tAVK848BgJgj7zBn)_