### PR TITLE
react-router v7 対応 (v8 移行を見越したインポート整理を含む)

### DIFF
--- a/client/component/atom/control-container/control-error-message.tsx
+++ b/client/component/atom/control-container/control-error-message.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable no-useless-computed-key */
+//
 
 import {ReactElement, ReactNode} from "react";
 import {FieldPath, UseFormReturn} from "react-hook-form";
-import {Path} from "react-router-dom";
 import {ControlErrorMessage as ZographiaControlErrorMessage} from "zographia";
 import {create} from "/client/component/create";
 
@@ -33,12 +32,3 @@ export const ControlErrorMessage = create(
 
   }
 );
-
-
-function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
-  const props = {
-    to: href,
-    ["viewTransition"]: useTransition
-  };
-  return props;
-};

--- a/client/component/atom/control-container/control-error-message.tsx
+++ b/client/component/atom/control-container/control-error-message.tsx
@@ -38,7 +38,7 @@ export const ControlErrorMessage = create(
 function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
   const props = {
     to: href,
-    ["unstable_viewTransition"]: useTransition
+    ["viewTransition"]: useTransition
   };
   return props;
 };

--- a/client/component/atom/link/link.tsx
+++ b/client/component/atom/link/link.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ComponentProps, ReactElement, ReactNode, Ref, useCallback} from "react";
-import {Path, Link as RouterLink} from "react-router-dom";
+import {Path, Link as RouterLink} from "react-router";
 import {Link as ZographiaLink} from "zographia";
 import {createWithRef} from "/client/component/create";
 

--- a/client/component/atom/link/link.tsx
+++ b/client/component/atom/link/link.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-computed-key */
+//
 
 import {ComponentProps, ReactElement, ReactNode, Ref, useCallback} from "react";
 import {Path, Link as RouterLink} from "react-router-dom";
@@ -23,7 +23,7 @@ export const Link = createWithRef(
 
     const renderComponent = useCallback(function (props: any): ReactElement {
       return (
-        <RouterLink {...getRouterLinkProps(href, useTransition)} {...props}/>
+        <RouterLink to={href} viewTransition={useTransition} {...props}/>
       );
     }, [href, useTransition]);
 
@@ -39,12 +39,3 @@ export const Link = createWithRef(
 
   }
 );
-
-
-function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
-  const props = {
-    to: href,
-    ["viewTransition"]: useTransition
-  };
-  return props;
-};

--- a/client/component/atom/link/link.tsx
+++ b/client/component/atom/link/link.tsx
@@ -44,7 +44,7 @@ export const Link = createWithRef(
 function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
   const props = {
     to: href,
-    ["unstable_viewTransition"]: useTransition
+    ["viewTransition"]: useTransition
   };
   return props;
 };

--- a/client/component/atom/simple-link/simple-link.tsx
+++ b/client/component/atom/simple-link/simple-link.tsx
@@ -37,7 +37,7 @@ export const SimpleLink = createWithRef(
 function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
   const props = {
     to: href,
-    ["unstable_viewTransition"]: useTransition
+    ["viewTransition"]: useTransition
   };
   return props;
 };

--- a/client/component/atom/simple-link/simple-link.tsx
+++ b/client/component/atom/simple-link/simple-link.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-computed-key */
+//
 
 import {ReactElement, ReactNode, Ref} from "react";
 import {Path, Link as RouterLink} from "react-router-dom";
@@ -23,7 +23,8 @@ export const SimpleLink = createWithRef(
     return (
       <RouterLink
         styleName="root"
-        {...getRouterLinkProps(href, useTransition)}
+        to={href}
+        viewTransition={useTransition}
         {...rest}
       >
         {children}
@@ -32,12 +33,3 @@ export const SimpleLink = createWithRef(
 
   }
 );
-
-
-function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
-  const props = {
-    to: href,
-    ["viewTransition"]: useTransition
-  };
-  return props;
-};

--- a/client/component/atom/simple-link/simple-link.tsx
+++ b/client/component/atom/simple-link/simple-link.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement, ReactNode, Ref} from "react";
-import {Path, Link as RouterLink} from "react-router-dom";
+import {Path, Link as RouterLink} from "react-router";
 import {createWithRef} from "/client/component/create";
 
 

--- a/client/component/atom/tab/link-tab.tsx
+++ b/client/component/atom/tab/link-tab.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-computed-key */
+//
 
 import {ComponentProps, ReactElement, ReactNode, Ref, useCallback} from "react";
 import {Path, Link as RouterLink} from "react-router-dom";
@@ -23,7 +23,7 @@ export const LinkTab = createWithRef(
 
     const renderComponent = useCallback(function (props: any): ReactElement {
       return (
-        <RouterLink {...getRouterLinkProps(href, useTransition)} {...props}/>
+        <RouterLink to={href} viewTransition={useTransition} {...props}/>
       );
     }, [href, useTransition]);
 
@@ -35,12 +35,3 @@ export const LinkTab = createWithRef(
 
   }
 );
-
-
-function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
-  const props = {
-    to: href,
-    ["viewTransition"]: useTransition
-  };
-  return props;
-};

--- a/client/component/atom/tab/link-tab.tsx
+++ b/client/component/atom/tab/link-tab.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ComponentProps, ReactElement, ReactNode, Ref, useCallback} from "react";
-import {Path, Link as RouterLink} from "react-router-dom";
+import {Path, Link as RouterLink} from "react-router";
 import {Tab as ZographiaTab} from "zographia";
 import {createWithRef} from "/client/component/create";
 

--- a/client/component/atom/tab/link-tab.tsx
+++ b/client/component/atom/tab/link-tab.tsx
@@ -40,7 +40,7 @@ export const LinkTab = createWithRef(
 function getRouterLinkProps(href: string | Partial<Path>, useTransition: boolean): any {
   const props = {
     to: href,
-    ["unstable_viewTransition"]: useTransition
+    ["viewTransition"]: useTransition
   };
   return props;
 };

--- a/client/component/compound/article-list/article-card.tsx
+++ b/client/component/compound/article-list/article-card.tsx
@@ -4,7 +4,7 @@ import {faEdit, faRight, faTrashAlt} from "@fortawesome/sharp-regular-svg-icons"
 import dayjs from "dayjs";
 import truncateMarkdown from "markdown-truncate";
 import {ReactElement} from "react";
-import {useMatch} from "react-router-dom";
+import {useMatch} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, Card, CardBody, CardFooter, Collapsible, CollapsibleBody, GeneralIcon, LinkIconbag, MultiLineText, Tag, useTrans} from "zographia";
 import {Link} from "/client/component/atom/link";
 import {Markdown} from "/client/component/atom/markdown";

--- a/client/component/compound/dictionary-header/dictionary-header.tsx
+++ b/client/component/compound/dictionary-header/dictionary-header.tsx
@@ -2,7 +2,7 @@
 
 import {faBook, faCircleInfo, faCog, faImage, faListCheck, faQuotes, faScroll} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useMatch} from "react-router-dom";
+import {useMatch} from "react-router";
 import {AdditionalProps, GeneralIcon, Indicator, TabIconbag, TabList, useTrans} from "zographia";
 import {LinkTab} from "/client/component/atom/tab";
 import {MainContainer} from "/client/component/compound/page";

--- a/client/component/compound/edit-article-dialog/edit-article-dialog.tsx
+++ b/client/component/compound/edit-article-dialog/edit-article-dialog.tsx
@@ -3,7 +3,7 @@
 import {faArrowUpRightFromSquare, faCheck} from "@fortawesome/sharp-regular-svg-icons";
 import {Fragment, MouseEvent, ReactElement, RefObject, cloneElement, useCallback, useRef, useState} from "react";
 import {UseFormReturn} from "react-hook-form";
-import {useHref} from "react-router-dom";
+import {useHref} from "react-router";
 import rison from "rison";
 import {
   Button,

--- a/client/component/compound/edit-example-dialog/edit-example-dialog.tsx
+++ b/client/component/compound/edit-example-dialog/edit-example-dialog.tsx
@@ -3,7 +3,7 @@
 import {faArrowUpRightFromSquare, faCheck} from "@fortawesome/sharp-regular-svg-icons";
 import {Fragment, MouseEvent, ReactElement, Ref, RefObject, cloneElement, isValidElement, useCallback, useRef, useState} from "react";
 import {UseFormReturn} from "react-hook-form";
-import {useHref} from "react-router-dom";
+import {useHref} from "react-router";
 import rison from "rison";
 import {
   Button,

--- a/client/component/compound/edit-word-dialog/edit-word-dialog.tsx
+++ b/client/component/compound/edit-word-dialog/edit-word-dialog.tsx
@@ -3,7 +3,7 @@
 import {faArrowUpRightFromSquare, faCheck} from "@fortawesome/sharp-regular-svg-icons";
 import {Fragment, MouseEvent, ReactElement, Ref, RefObject, cloneElement, isValidElement, useCallback, useRef, useState} from "react";
 import {UseFormReturn} from "react-hook-form";
-import {useHref} from "react-router-dom";
+import {useHref} from "react-router";
 import rison from "rison";
 import {
   Button,

--- a/client/component/compound/example-list/example-card.tsx
+++ b/client/component/compound/example-list/example-card.tsx
@@ -3,7 +3,7 @@
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faCircleInfo, faEdit, faHandPointRight, faShare, faTrashAlt, faTriangleExclamation} from "@fortawesome/sharp-regular-svg-icons";
 import {Fragment, ReactElement, useRef} from "react";
-import {useHref} from "react-router-dom";
+import {useHref} from "react-router";
 import {
   AdditionalProps,
   Button,

--- a/client/component/compound/login-form/login-form-hook.ts
+++ b/client/component/compound/login-form/login-form-hook.ts
@@ -1,7 +1,7 @@
 //
 
 import {BaseSyntheticEvent, useMemo} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {Asserts, object, string} from "yup";
 import {useLoginRequest} from "/client/hook/auth";
 import {UseFormReturn, useForm} from "/client/hook/form";

--- a/client/component/compound/page/page.tsx
+++ b/client/component/compound/page/page.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement, ReactNode} from "react";
-import {ScrollRestoration} from "react-router-dom";
+import {ScrollRestoration} from "react-router";
 import {AdditionalProps, data} from "zographia";
 import {Title} from "/client/component/atom/title";
 import {Footer} from "/client/component/compound/footer";

--- a/client/component/compound/register-form/register-form-hook.ts
+++ b/client/component/compound/register-form/register-form-hook.ts
@@ -1,7 +1,7 @@
 //
 
 import {BaseSyntheticEvent, useMemo} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {Asserts, boolean, object, string} from "yup";
 import {useLoginRequest} from "/client/hook/auth";
 import {UseFormReturn, useForm} from "/client/hook/form";

--- a/client/component/core/routing/routing.tsx
+++ b/client/component/core/routing/routing.tsx
@@ -1,7 +1,8 @@
 //
 
 import {ReactElement} from "react";
-import {Route, RouterProvider, createBrowserRouter, createRoutesFromElements} from "react-router-dom";
+import {Route, createBrowserRouter, createRoutesFromElements} from "react-router";
+import {RouterProvider} from "react-router/dom";
 import {create} from "/client/component/create";
 import {ErrorPage} from "/client/component/page/error-page";
 import {ToplevelRoute} from "./toplevel-route";

--- a/client/component/core/routing/toplevel-route.tsx
+++ b/client/component/core/routing/toplevel-route.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement, Suspense, useEffect} from "react";
-import {Outlet, useLocation} from "react-router-dom";
+import {Outlet, useLocation} from "react-router";
 import {create} from "/client/component/create";
 import {LoadingPage} from "/client/component/page/loading-page";
 import {sendAnalyticsEvent} from "/client/util/gtag";

--- a/client/component/form/add-dictionary-button/add-dictionary-button-hook.ts
+++ b/client/component/form/add-dictionary-button/add-dictionary-button-hook.ts
@@ -1,7 +1,7 @@
 //
 
 import {BaseSyntheticEvent, useCallback} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {Asserts, object, string} from "yup";
 import {useMe} from "/client/hook/auth";
 import {UseFormReturn, useForm} from "/client/hook/form";

--- a/client/component/form/change-dictionary-param-name-form/change-dictionary-param-name-form-hook.ts
+++ b/client/component/form/change-dictionary-param-name-form/change-dictionary-param-name-form-hook.ts
@@ -1,7 +1,7 @@
 //
 
 import {BaseSyntheticEvent, useMemo} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {Asserts, object, string} from "yup";
 import {UseFormReturn, useForm} from "/client/hook/form";
 import {invalidateResponses, useRequest} from "/client/hook/request";

--- a/client/component/form/change-dictionary-param-name-form/change-dictionary-param-name-form.tsx
+++ b/client/component/form/change-dictionary-param-name-form/change-dictionary-param-name-form.tsx
@@ -2,7 +2,7 @@
 
 import {faCheck} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useHref} from "react-router-dom";
+import {useHref} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, ControlContainer, GeneralIcon, Input, InputAddon, useTrans} from "zographia";
 import {ControlErrorMessage} from "/client/component/atom/control-container";
 import {create} from "/client/component/create";

--- a/client/component/form/download-dictionary-form/download-dictionary-form.tsx
+++ b/client/component/form/download-dictionary-form/download-dictionary-form.tsx
@@ -2,7 +2,7 @@
 
 import {faCircleCheck, faDownload, faExclamation, faLeft} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, Link, LinkIconbag, LoadingIcon, MultiLineText, data, useTrans} from "zographia";
 import {create} from "/client/component/create";
 import {useDownloadDictionary} from "./download-dictionary-form-hook";

--- a/client/component/form/logout-button/logout-button.tsx
+++ b/client/component/form/logout-button/logout-button.tsx
@@ -2,7 +2,7 @@
 
 import {faSignOutAlt} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement, useCallback} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, useTrans} from "zographia";
 import {create} from "/client/component/create";
 import {useLogoutRequest} from "/client/hook/auth";

--- a/client/component/form/queue-download-dictionary-button/queue-download-dictionary-button-hook.ts
+++ b/client/component/form/queue-download-dictionary-button/queue-download-dictionary-button-hook.ts
@@ -1,7 +1,7 @@
 //
 
 import {BaseSyntheticEvent, useMemo} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {Asserts, object, string} from "yup";
 import {UseFormReturn, useForm} from "/client/hook/form";
 import {useRequest} from "/client/hook/request";

--- a/client/component/form/queue-upload-dictionary-button/queue-upload-dictionary-button-hook.ts
+++ b/client/component/form/queue-upload-dictionary-button/queue-upload-dictionary-button-hook.ts
@@ -1,7 +1,7 @@
 //
 
 import {BaseSyntheticEvent, useCallback} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {Asserts, mixed, object} from "yup";
 import {UseFormReturn, useForm} from "/client/hook/form";
 import {useRequestFile} from "/client/hook/request";

--- a/client/component/form/upload-dictionary-form/upload-dictionary-form.tsx
+++ b/client/component/form/upload-dictionary-form/upload-dictionary-form.tsx
@@ -2,7 +2,7 @@
 
 import {faCircleCheck, faExclamation, faLeft} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps, GeneralIcon, Link, LinkIconbag, LoadingIcon, MultiLineText, data, useTrans} from "zographia";
 import {create} from "/client/component/create";
 import {useUploadDictionaryForm} from "./upload-dictionary-form-hook";

--- a/client/component/page/activate-me-page/activate-me-page-hook.ts
+++ b/client/component/page/activate-me-page/activate-me-page-hook.ts
@@ -1,7 +1,7 @@
 //
 
 import {useCallback} from "react";
-import {useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router";
 import {useRequest} from "/client/hook/request";
 import {useToast} from "/client/hook/toast";
 import {switchResponse} from "/client/util/response";

--- a/client/component/page/dictionary-article-single-part/dictionary-article-single-part-loader.ts
+++ b/client/component/page/dictionary-article-single-part/dictionary-article-single-part-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/dictionary-article-single-part/dictionary-article-single-part.tsx
+++ b/client/component/page/dictionary-article-single-part/dictionary-article-single-part.tsx
@@ -2,7 +2,7 @@
 
 import {faLeft} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useMatch, useParams} from "react-router-dom";
+import {useMatch, useParams} from "react-router";
 import {AdditionalProps, GeneralIcon, LinkIconbag, useTrans} from "zographia";
 import {GoogleAdsense} from "/client/component/atom/google-adsense";
 import {Link} from "/client/component/atom/link";

--- a/client/component/page/dictionary-page/dictionary-page-loader.ts
+++ b/client/component/page/dictionary-page/dictionary-page-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs, ShouldRevalidateFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs, ShouldRevalidateFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/dictionary-proposal-part/dictionary-proposal-part-loader.ts
+++ b/client/component/page/dictionary-proposal-part/dictionary-proposal-part-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/dictionary-setting-authority-part/dictionary-setting-authority-part.tsx
+++ b/client/component/page/dictionary-setting-authority-part/dictionary-setting-authority-part.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-closing-bracket-location */
 
 import {ReactElement} from "react";
-import {useOutletContext} from "react-router-dom";
+import {useOutletContext} from "react-router";
 import {AdditionalProps, MultiLineText, data, useTrans} from "zographia";
 import {MemberList} from "/client/component/compound/member-list";
 import {create} from "/client/component/create";

--- a/client/component/page/dictionary-setting-display-part/dictionary-setting-display-part.tsx
+++ b/client/component/page/dictionary-setting-display-part/dictionary-setting-display-part.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useOutletContext} from "react-router-dom";
+import {useOutletContext} from "react-router";
 import {AdditionalProps, MultiLineText, useTrans} from "zographia";
 import {create} from "/client/component/create";
 import {ChangeDictionaryFontForm} from "/client/component/form/change-dictionary-font-form";

--- a/client/component/page/dictionary-setting-editing-part/dictionary-setting-editing-part.tsx
+++ b/client/component/page/dictionary-setting-editing-part/dictionary-setting-editing-part.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useOutletContext} from "react-router-dom";
+import {useOutletContext} from "react-router";
 import {AdditionalProps, MultiLineText, useTrans} from "zographia";
 import {Link} from "/client/component/atom/link";
 import {create} from "/client/component/create";

--- a/client/component/page/dictionary-setting-file-part/dictionary-setting-file-part.tsx
+++ b/client/component/page/dictionary-setting-file-part/dictionary-setting-file-part.tsx
@@ -2,7 +2,7 @@
 
 import {faTriangleExclamation} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useOutletContext} from "react-router-dom";
+import {useOutletContext} from "react-router";
 import {AdditionalProps, Callout, CalloutBody, CalloutIconContainer, GeneralIcon, MultiLineText, useTrans} from "zographia";
 import {Link} from "/client/component/atom/link";
 import {create} from "/client/component/create";

--- a/client/component/page/dictionary-setting-general-part/dictionary-setting-general-part.tsx
+++ b/client/component/page/dictionary-setting-general-part/dictionary-setting-general-part.tsx
@@ -2,7 +2,7 @@
 
 import {faTriangleExclamation} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useOutletContext} from "react-router-dom";
+import {useOutletContext} from "react-router";
 import {AdditionalProps, Callout, CalloutBody, CalloutIconContainer, GeneralIcon, MultiLineText, data, useTrans} from "zographia";
 import {create} from "/client/component/create";
 import {ChangeDictionaryExplanationForm} from "/client/component/form/change-dictionary-explanation-form";

--- a/client/component/page/dictionary-setting-part/dictionary-setting-part-loader.ts
+++ b/client/component/page/dictionary-setting-part/dictionary-setting-part-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/dictionary-setting-part/dictionary-setting-part.tsx
+++ b/client/component/page/dictionary-setting-part/dictionary-setting-part.tsx
@@ -2,7 +2,7 @@
 
 import {faDisplay, faFile, faMemo, faPen, faSliders, faUsers} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {Outlet, useMatch} from "react-router-dom";
+import {Outlet, useMatch} from "react-router";
 import {AdditionalProps, GeneralIcon, TabIconbag, TabList, useTrans} from "zographia";
 import {LinkTab} from "/client/component/atom/tab";
 import {create} from "/client/component/create";

--- a/client/component/page/dictionary-setting-template-part/dictionary-setting-template-part.tsx
+++ b/client/component/page/dictionary-setting-template-part/dictionary-setting-template-part.tsx
@@ -2,7 +2,7 @@
 
 import {faPlus} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useOutletContext} from "react-router-dom";
+import {useOutletContext} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, useTrans} from "zographia";
 import {EditTemplateWordDialog} from "/client/component/compound/edit-word-dialog";
 import {TemplateWordList} from "/client/component/compound/template-word-list";

--- a/client/component/page/document-page/document-page-loader.ts
+++ b/client/component/page/document-page/document-page-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/document-page/document-page.tsx
+++ b/client/component/page/document-page/document-page.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps, useLocale} from "zographia";
 import {Markdown} from "/client/component/atom/markdown";
 import {Header} from "/client/component/compound/header";

--- a/client/component/page/download-dictionary-page/download-dictionary-page.tsx
+++ b/client/component/page/download-dictionary-page/download-dictionary-page.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps} from "zographia";
 import {Header} from "/client/component/compound/header";
 import {MainContainer, Page} from "/client/component/compound/page";

--- a/client/component/page/edit-article-page/edit-article-page-loader.ts
+++ b/client/component/page/edit-article-page/edit-article-page-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import rison from "rison";
 import {EditArticleInitialData} from "/client/component/compound/edit-article-form";
 import {fetchResponse} from "/client/hook/request";

--- a/client/component/page/edit-article-page/edit-article-page.tsx
+++ b/client/component/page/edit-article-page/edit-article-page.tsx
@@ -2,7 +2,7 @@
 
 import {faCheck} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useLoaderData} from "react-router-dom";
+import {useLoaderData} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, useTrans} from "zographia";
 import {EditArticleForm, useEditArticle} from "/client/component/compound/edit-article-form";
 import {Header} from "/client/component/compound/header";

--- a/client/component/page/edit-example-page/edit-example-page-loader.ts
+++ b/client/component/page/edit-example-page/edit-example-page-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import rison from "rison";
 import {EditExampleInitialData} from "/client/component/compound/edit-example-form";
 import {fetchResponse} from "/client/hook/request";

--- a/client/component/page/edit-example-page/edit-example-page.tsx
+++ b/client/component/page/edit-example-page/edit-example-page.tsx
@@ -2,7 +2,7 @@
 
 import {faCheck} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useLoaderData} from "react-router-dom";
+import {useLoaderData} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, useTrans} from "zographia";
 import {EditExampleForm, useEditExample} from "/client/component/compound/edit-example-form";
 import {Header} from "/client/component/compound/header";

--- a/client/component/page/edit-word-page/edit-word-page-loader.ts
+++ b/client/component/page/edit-word-page/edit-word-page-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import rison from "rison";
 import {EditWordInitialData} from "/client/component/compound/edit-word-form";
 import {fetchResponse} from "/client/hook/request";

--- a/client/component/page/edit-word-page/edit-word-page.tsx
+++ b/client/component/page/edit-word-page/edit-word-page.tsx
@@ -2,7 +2,7 @@
 
 import {faCheck} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useLoaderData} from "react-router-dom";
+import {useLoaderData} from "react-router";
 import {AdditionalProps, Button, ButtonIconbag, GeneralIcon, useTrans} from "zographia";
 import {EditWordForm, useEditWord} from "/client/component/compound/edit-word-form";
 import {Header} from "/client/component/compound/header";

--- a/client/component/page/error-page/error-page.tsx
+++ b/client/component/page/error-page/error-page.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {isRouteErrorResponse, useRouteError} from "react-router-dom";
+import {isRouteErrorResponse, useRouteError} from "react-router";
 import {AdditionalProps} from "zographia";
 import {Header} from "/client/component/compound/header";
 import {MainContainer, Page} from "/client/component/compound/page";

--- a/client/component/page/upload-dictionary-page/upload-dictionary-page.tsx
+++ b/client/component/page/upload-dictionary-page/upload-dictionary-page.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps} from "zographia";
 import {Header} from "/client/component/compound/header";
 import {MainContainer, Page} from "/client/component/compound/page";

--- a/client/component/page/user-appearance-part/user-appearance-part.tsx
+++ b/client/component/page/user-appearance-part/user-appearance-part.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps, useTrans} from "zographia";
 import {create} from "/client/component/create";
 import {ChangeAppearanceForm} from "/client/component/form/change-appearance-form";

--- a/client/component/page/user-developer-part/user-developer-part-loader.ts
+++ b/client/component/page/user-developer-part/user-developer-part-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/user-developer-part/user-developer-part.tsx
+++ b/client/component/page/user-developer-part/user-developer-part.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement, useMemo} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps, MultiLineText, useTrans} from "zographia";
 import {Link} from "/client/component/atom/link";
 import {ApiCredentialList} from "/client/component/compound/api-credential-list";

--- a/client/component/page/user-dictionary-part/user-dictionary-part.tsx
+++ b/client/component/page/user-dictionary-part/user-dictionary-part.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps} from "zographia";
 import {DictionaryList} from "/client/component/compound/dictionary-list";
 import {create} from "/client/component/create";

--- a/client/component/page/user-notification-part/user-notification-part-loader.ts
+++ b/client/component/page/user-notification-part/user-notification-part-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/user-notification-part/user-notification-part.tsx
+++ b/client/component/page/user-notification-part/user-notification-part.tsx
@@ -1,7 +1,7 @@
 //
 
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps} from "zographia";
 import {InvitationList} from "/client/component/compound/invitation-list";
 import {create} from "/client/component/create";

--- a/client/component/page/user-page/user-page-loader.ts
+++ b/client/component/page/user-page/user-page-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/user-page/user-page.tsx
+++ b/client/component/page/user-page/user-page.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-closing-bracket-location */
 
 import {Fragment, ReactElement, Suspense} from "react";
-import {Outlet, useMatch, useParams} from "react-router-dom";
+import {Outlet, useMatch, useParams} from "react-router";
 import {AdditionalProps, LoadingIcon} from "zographia";
 import {Header} from "/client/component/compound/header";
 import {MainContainer, Page} from "/client/component/compound/page";

--- a/client/component/page/user-setting-part/user-setting-part-loader.ts
+++ b/client/component/page/user-setting-part/user-setting-part-loader.ts
@@ -1,6 +1,6 @@
 //
 
-import {LoaderFunctionArgs} from "react-router-dom";
+import {LoaderFunctionArgs} from "react-router";
 import {fetchResponse} from "/client/hook/request";
 import {ResponseError} from "/client/util/response-error";
 

--- a/client/component/page/user-setting-part/user-setting-part.tsx
+++ b/client/component/page/user-setting-part/user-setting-part.tsx
@@ -2,7 +2,7 @@
 
 import {faTriangleExclamation} from "@fortawesome/sharp-regular-svg-icons";
 import {ReactElement} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {AdditionalProps, Callout, CalloutBody, CalloutIconContainer, GeneralIcon, MultiLineText, data, useTrans} from "zographia";
 import {create} from "/client/component/create";
 import {ChangeMyAvatarForm} from "/client/component/form/change-my-avatar-form";

--- a/client/hook/dictionary.ts
+++ b/client/hook/dictionary.ts
@@ -1,7 +1,7 @@
 //
 
 import {useMemo} from "react";
-import {useParams} from "react-router-dom";
+import {useParams} from "react-router";
 import {useSuspenseResponse} from "/client/hook/request";
 import {Dictionary, DictionaryWithExecutors} from "/server/internal/skeleton";
 

--- a/client/hook/search.ts
+++ b/client/hook/search.ts
@@ -1,7 +1,7 @@
 //
 
 import {Dispatch, SetStateAction, useCallback, useEffect, useRef, useState} from "react";
-import {useSearchParams as useRawSearch} from "react-router-dom";
+import {useSearchParams as useRawSearch} from "react-router";
 import {useDebouncedCallback} from "zographia";
 import {resolveStateAction} from "/client/util/misc";
 


### PR DESCRIPTION
## 概要

PR #154 で `react-router-dom` を v6 (6.21.1) → v7 (7.18.1) に更新したことに伴うコード側の追従修正と、v8 移行を見越したインポートの整理を行います。

## 変更内容

### 1. `unstable_viewTransition` → `viewTransition` のリネーム追従
v7 では、v6 で `unstable_viewTransition` だったビュートランジション用プロパティが安定版の `viewTransition` にリネームされ、旧名は削除されました。旧名のままだとビュートランジションが黙って無効化されるため、新名に置き換えます。

### 2. `getRouterLinkProps` ヘルパーの廃止
`react-router` の `<Link>` へ渡すプロパティ (`to` / `viewTransition`) を、ヘルパー関数を経由せず JSX タグ内に直接記述する形に変更しました。computed key がなくなるため `no-useless-computed-key` の eslint-disable も除去しています。`control-error-message.tsx` の `getRouterLinkProps` は未使用のデッドコードだったため関数ごと削除しました。

### 3. `react-router-dom` → `react-router` のインポート書き換え (v8 を見越して)
v8 で `react-router-dom` パッケージが廃止されることを見越し、`client` 配下の全インポート (58 ファイル) を `react-router-dom` から `react-router` に変更しました。DOM 依存の `RouterProvider` のみ、v8 の指針に従い `react-router/dom` から取得します (`routing.tsx`)。

- コードベースが使用する API (`useParams` `useNavigate` `useOutletContext` `useMatch` `useHref` `useLoaderData` `useLocation` `useSearchParams` `useRouteError` `isRouteErrorResponse` `Outlet` `Link` `Route` `ScrollRestoration` `createBrowserRouter` `createRoutesFromElements`、型 `LoaderFunctionArgs` `Path` `ShouldRevalidateFunctionArgs`) はすべて `react-router` 本体に存在することを v7.18.1 の型定義で確認済み。
- `RouterProvider` のみ `react-router/dom` (DOM 版・flushSync 内包) から取得。`react-router@7.18.1` は `./dom` サブパスを持ち CJS にも対応しているため、現行の webpack + CommonJS 構成でも解決されます。

## package.json の依存について

`react-router-dom@7.18.1` は `react-router@7.18.1` を**厳密固定**で依存しているため、`react-router` / `react-router/dom` は現時点でも node_modules 上に必ず存在し、直接インポートは v7 で問題なく解決されます。そのため今回は `package.json` / `package-lock.json` は変更していません (両者は整合したまま)。

`package.json` の依存宣言自体を `react-router-dom` → `react-router` に入れ替える作業は、`package-lock.json` の再生成 (ローカルでの `npm install`) を伴うため、**v8 着手時にまとめて行う follow-up** とします。

## 動作確認について

Font Awesome Pro の非公開レジストリ (`npm.fontawesome.com`) が本環境では認証情報を持たず 403 となるため、`npm run build` / `npm run lint` はこの環境で実行できていません。ローカル (FA Pro のライセンストークンが利用できる環境) でのビルド・動作確認をお願いします。特にルート遷移・ビュートランジション・エラーページ・検索 (`useSearchParams`) の動作確認を推奨します。